### PR TITLE
Feat: HyClusVi improvements, talk entries, SVG diagrams — Fixes #22, #24, #25

### DIFF
--- a/_portfolio/HyClusVi.md
+++ b/_portfolio/HyClusVi.md
@@ -5,19 +5,16 @@ excerpt: "A short Undergraduate Project for HSI Clustering Visualization<br/><im
 collection: portfolio
 ---
 
-This project explored the application of deep convolutional autoencoders and high-dimensional data visualization techniques to hyperspectral imagery from mining operations. The core challenge was dimensionality reduction -- mapping hundreds of spectral bands into compact latent representations that preserve discriminative structure for mineral characterization and sample provenance identification.
+Hyperspectral imaging produces data cubes with hundreds of spectral bands per pixel, creating a fundamental dimensionality reduction and visualization challenge: how do you compress this high-dimensional spectral information into compact representations that preserve meaningful structure for mineral identification and sample provenance discrimination? HyClusVi addresses this problem by combining deep autoencoders with nonlinear embedding techniques (t-SNE) to transform raw spectral data into interpretable low-dimensional visualizations, enabling clustering and classification of mineral samples from industrial comminution circuits.
 
+![Pipeline](/images/projects/hyclusvi_pipeline.svg)
 
 The Context
 ======
 
-In the first execution of the Data Science Project course (Data Science Project CC5214) of the Department of Computer Science, of the Faculty of Physical and Mathematical Sciences of the University of Chile, our laboratory proposed the project "Clusterization and Identification of mineral species from Hyperspectral images". 
+This project originated in the first edition of the Data Science Project course (CC5214) at the Department of Computer Science, Faculty of Physical and Mathematical Sciences, Universidad de Chile. Our laboratory proposed the project "Clusterization and Identification of mineral species from Hyperspectral images", and three students worked on the formulation, analysis, and evaluation of the system using real data: monthly composites from comminution feeders of three different productive sectors of a large mining company operating nationwide.
 
-It is in this context 3 students worked on the formulation, analysis and evaluation of this project for processing real data of monthly composites from comminution feeders of 3 different productive sectors of a large mining company in active work nationwide.
-
-In this project, the students were able to carry out the task of researching and implementing deep machine learning systems in the analysis of high-dimensional hyperspectral images. This work has made it possible to complement scientific and visualization tools that we are currently promoting and disseminating in the national mining industry.
-
-From the results obtained by the team, the techniques for displaying clustering results using Big Data stand out, which have allowed us to improve our results reporting system.
+The students researched and implemented deep learning systems for the analysis of high-dimensional hyperspectral images. This work complemented scientific and visualization tools that we were actively promoting and disseminating in the national mining industry. The resulting techniques for visualizing clustering results at scale have since improved our results reporting system.
 
 
 The data
@@ -107,10 +104,10 @@ In the case of sorting the spectra by the origin month, no visual organization i
 
 
 
-Deep Autoencoders 
+Deep Autoencoders
 ------
 
-For this work the use of the individual spectrum as the input was considered. A preliminary approach corresponded to apply a convolution autoencoder to attempt reduce the dimensionality of the hyperspectral data. Here, an initial hard reduction to 4 dimensions was considered by using keras from tensorflow. 
+The core dimensionality reduction engine is a symmetric dense autoencoder. Each individual spectrum serves as the input, and the network learns a compressed latent representation through a bottleneck architecture. The encoder path progressively reduces dimensionality (input &rarr; 128 &rarr; 64 &rarr; 32 &rarr; 16 &rarr; 4), and the decoder mirrors this structure (4 &rarr; 16 &rarr; 32 &rarr; 64 &rarr; 128 &rarr; output). All hidden layers use **tanh** activation with **orthogonal** kernel initialization, which helps preserve gradient flow and avoid degenerate representations. Input spectra are normalized with **MinMaxScaler** before training, and the output layer uses sigmoid activation with binary cross-entropy loss. The bottleneck of 4 dimensions was chosen as an aggressive compression target; a second variant with 16 latent dimensions was also evaluated for comparison.
 
 ```python
 from tensorflow.keras import layers, models, callbacks
@@ -610,4 +607,9 @@ colors = ['C0', 'C1', 'C2', 'C3', 'C4', 'C5', 'C6', 'C7', 'C8', 'C9', 'C10', 'C1
 
 ![img](/files/portfolio/HyClus/120.png)
 
-*This project does not have a public repository. The data and detailed implementation remain confidential due to the industrial origin of the samples.*
+*This project was developed as part of the CC5214 Data Science Project course at Universidad de Chile. It does not have a public repository; the data and detailed implementation remain confidential due to the industrial origin of the samples.*
+
+Connection to HIDSAG and Geometallurgy
+======
+
+HyClusVi represents an early exploration of the dimensionality reduction and visualization pipeline that later became central to the [HIDSAG](/portfolio/HIDSAG) research program. The insights from this student project -- particularly the effectiveness of autoencoder-based spectral compression and t-SNE visualization for mineral discrimination -- informed subsequent work on hyperspectral data analysis for geometallurgical estimation. The topic modelling approach presented at [Procemin Geomet 2022](/talks/2022-10-01-talk-procemin-geomet) builds directly on the spectral representation ideas first tested here, extending them with probabilistic models (LDA) for mineral abundance estimation from SWIR and VNIR imagery.

--- a/_talks/2016-07-13-talk-sam-brazil.md
+++ b/_talks/2016-07-13-talk-sam-brazil.md
@@ -1,0 +1,16 @@
+---
+title: "Channelized facies recovery based on weighted compressed sensing"
+collection: talks
+type: "Conference presentation"
+permalink: /talks/2016-07-13-talk-sam-brazil
+venue: "2016 IEEE Sensor Array and Multichannel Signal Processing Workshop (SAM)"
+date: 2016-07-13
+location: "Rio de Janeiro, Brazil"
+---
+
+Presented at IEEE SAM 2016 in Rio de Janeiro. This was Felipe's first international conference presentation, supported by a travel grant from the Department of Electrical Engineering (DIE) at Universidad de Chile. The paper proposes a weighted compressed sensing (WCS) algorithm for channelized facies recovery, integrating signal structure in the DCT transform domain with multiple-point statistics. Results show excellent reconstruction even with 0.3%-1.0% sampling rates. Joint work with Hernan Calderon, Jorge F. Silva, Julian Ortiz, and Alvaro Egana.
+
+More details?
+------
+
+[DOI: 10.1109/SAM.2016.7569627](https://doi.org/10.1109/SAM.2016.7569627)

--- a/_talks/2021-12-13-talk-agu-fall-meeting.md
+++ b/_talks/2021-12-13-talk-agu-fall-meeting.md
@@ -1,0 +1,16 @@
+---
+title: "Analysis of seismic tomography and geological data using ML methods"
+collection: talks
+type: "Conference poster"
+permalink: /talks/2021-12-13-talk-agu-fall-meeting
+venue: "AGU Fall Meeting 2021"
+date: 2021-12-13
+location: "New Orleans, USA (hybrid)"
+---
+
+Poster presented at AGU Fall Meeting 2021. Demonstrates ML techniques for understanding spatial relationships between large porphyry copper deposits in northern Chile using seismic tomography and geological data. The work shows connections between subduction processes and mineralization patterns. Contribution to ML methodology in collaboration with D. Comte and others.
+
+More details?
+------
+
+[Abstract on ADS](https://ui.adsabs.harvard.edu/abs/2021AGUFM.H35M1172C/abstract)

--- a/_talks/2022-10-01-talk-procemin-geomet.md
+++ b/_talks/2022-10-01-talk-procemin-geomet.md
@@ -1,0 +1,11 @@
+---
+title: "Geometallurgical estimation from hyperspectral images and topic modelling"
+collection: talks
+type: "Conference presentation"
+permalink: /talks/2022-10-01-talk-procemin-geomet
+venue: "18th International Conference on Mineral Processing and Geometallurgy (Procemin Geomet 2022)"
+date: 2022-10-01
+location: "Santiago, Chile"
+---
+
+Presented at Procemin Geomet 2022, the premier mineral processing conference in Latin America. Formalizes mineral sample characterization as a topic modelling task using Latent Dirichlet Allocation (LDA) on hyperspectral pixels. The analogy: minerals are "topics", spectral signatures are "words", each pixel is a "document". Provides experimental evidence on SWIR and VNIR wavelengths. Joint work with Alejandro Ehrenfeld, Felipe Garrido, Felipe Navarro, and Alvaro Egana.

--- a/images/projects/feelit_concept.svg
+++ b/images/projects/feelit_concept.svg
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400" viewBox="0 0 800 400">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" style="stop-color:#0d1b2a"/>
+      <stop offset="100%" style="stop-color:#1b2d45"/>
+    </linearGradient>
+    <linearGradient id="pinGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" style="stop-color:#00b4d8"/>
+      <stop offset="100%" style="stop-color:#0077b6"/>
+    </linearGradient>
+    <linearGradient id="timelineGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" style="stop-color:#00b4d8"/>
+      <stop offset="50%" style="stop-color:#48cae4"/>
+      <stop offset="100%" style="stop-color:#e07a2f"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="400" fill="url(#bg)"/>
+
+  <!-- Title -->
+  <text x="400" y="28" style="font-family:Arial,sans-serif;font-size:16px;font-weight:bold;fill:#48cae4;text-anchor:middle;">FeelIT &#x2014; Haptic Accessibility Concept</text>
+
+  <!-- Section dividers -->
+  <line x1="267" y1="38" x2="267" y2="280" style="stroke:#2a4a6b;stroke-width:1;stroke-dasharray:4,4;"/>
+  <line x1="533" y1="38" x2="533" y2="280" style="stroke:#2a4a6b;stroke-width:1;stroke-dasharray:4,4;"/>
+
+  <!-- ========== LEFT SECTION: Physical World ========== -->
+  <text x="133" y="55" style="font-family:Arial,sans-serif;font-size:12px;font-weight:bold;fill:#48cae4;text-anchor:middle;">Physical World</text>
+
+  <!-- 3D object (cube) -->
+  <polygon points="133,90 173,75 173,115 133,130" style="fill:#1a6b8a;stroke:#48cae4;stroke-width:1.5;"/>
+  <polygon points="133,90 93,75 93,115 133,130" style="fill:#0e4d6b;stroke:#48cae4;stroke-width:1.5;"/>
+  <polygon points="93,75 133,60 173,75 133,90" style="fill:#2090b0;stroke:#48cae4;stroke-width:1.5;"/>
+
+  <!-- Arrow down -->
+  <line x1="133" y1="138" x2="133" y2="165" style="stroke:#e07a2f;stroke-width:2;"/>
+  <polygon points="133,172 127,162 139,162" style="fill:#e07a2f;"/>
+
+  <!-- Eye with cross (visual impairment icon) -->
+  <ellipse cx="80" cy="195" rx="22" ry="14" style="fill:none;stroke:#e07a2f;stroke-width:1.5;"/>
+  <circle cx="80" cy="195" r="6" style="fill:none;stroke:#e07a2f;stroke-width:1.5;"/>
+  <line x1="60" y1="180" x2="100" y2="210" style="stroke:#ff4444;stroke-width:2;"/>
+
+  <!-- Hand touching surface (tactile icon) -->
+  <path d="M160,185 C160,185 170,178 175,185 C180,192 172,195 172,195 L165,205 C165,205 155,208 155,200 Z" style="fill:none;stroke:#48cae4;stroke-width:1.5;"/>
+  <line x1="145" y1="210" x2="190" y2="210" style="stroke:#48cae4;stroke-width:2;"/>
+  <!-- fingers -->
+  <line x1="172" y1="195" x2="178" y2="188" style="stroke:#48cae4;stroke-width:1.2;"/>
+  <line x1="170" y1="193" x2="176" y2="183" style="stroke:#48cae4;stroke-width:1.2;"/>
+
+  <!-- Label -->
+  <text x="80" y="230" style="font-family:Arial,sans-serif;font-size:9px;fill:#90a4ae;text-anchor:middle;">Visual Impairment</text>
+  <text x="170" y="230" style="font-family:Arial,sans-serif;font-size:9px;fill:#90a4ae;text-anchor:middle;">Tactile Sense</text>
+
+  <!-- ========== CENTER SECTION: Pin Array Display ========== -->
+  <text x="400" y="55" style="font-family:Arial,sans-serif;font-size:12px;font-weight:bold;fill:#48cae4;text-anchor:middle;">Pin Array Display</text>
+
+  <!-- Base platform -->
+  <rect x="310" y="210" width="180" height="12" rx="2" style="fill:#1a3a5c;stroke:#2a5a7c;stroke-width:1;"/>
+
+  <!-- Pins at varying heights (side view) - forming a relief pattern like a dome/sphere -->
+  <!-- Row of pins -->
+  <rect x="320" y="185" width="6" height="37" rx="1" style="fill:url(#pinGrad);"/>
+  <rect x="335" y="165" width="6" height="57" rx="1" style="fill:url(#pinGrad);"/>
+  <rect x="350" y="145" width="6" height="77" rx="1" style="fill:url(#pinGrad);"/>
+  <rect x="365" y="130" width="6" height="92" rx="1" style="fill:url(#pinGrad);"/>
+  <rect x="380" y="120" width="6" height="102" rx="1" style="fill:url(#pinGrad);"/>
+  <rect x="395" y="115" width="6" height="107" rx="1" style="fill:url(#pinGrad);"/>
+  <rect x="410" y="120" width="6" height="102" rx="1" style="fill:url(#pinGrad);"/>
+  <rect x="425" y="130" width="6" height="92" rx="1" style="fill:url(#pinGrad);"/>
+  <rect x="440" y="145" width="6" height="77" rx="1" style="fill:url(#pinGrad);"/>
+  <rect x="455" y="165" width="6" height="57" rx="1" style="fill:url(#pinGrad);"/>
+  <rect x="470" y="185" width="6" height="37" rx="1" style="fill:url(#pinGrad);"/>
+
+  <!-- Relief curve outline -->
+  <path d="M323,185 C340,155 370,120 398,115 C426,120 456,155 473,185" style="fill:none;stroke:#e07a2f;stroke-width:1.5;stroke-dasharray:3,3;"/>
+
+  <!-- Pin caps (top circles) -->
+  <circle cx="323" cy="183" r="4" style="fill:#48cae4;"/>
+  <circle cx="338" cy="163" r="4" style="fill:#48cae4;"/>
+  <circle cx="353" cy="143" r="4" style="fill:#48cae4;"/>
+  <circle cx="368" cy="128" r="4" style="fill:#48cae4;"/>
+  <circle cx="383" cy="118" r="4" style="fill:#48cae4;"/>
+  <circle cx="398" cy="113" r="4" style="fill:#00b4d8;"/>
+  <circle cx="413" cy="118" r="4" style="fill:#48cae4;"/>
+  <circle cx="428" cy="128" r="4" style="fill:#48cae4;"/>
+  <circle cx="443" cy="143" r="4" style="fill:#48cae4;"/>
+  <circle cx="458" cy="163" r="4" style="fill:#48cae4;"/>
+  <circle cx="473" cy="183" r="4" style="fill:#48cae4;"/>
+
+  <!-- Label -->
+  <text x="400" y="245" style="font-family:Arial,sans-serif;font-size:9px;fill:#90a4ae;text-anchor:middle;">Side view &#x2014; pins form relief of physical object</text>
+
+  <!-- Arrows between sections -->
+  <path d="M230,150 L290,150" style="fill:none;stroke:#e07a2f;stroke-width:1.5;marker-end:url(#arrowOrange);"/>
+  <polygon points="295,150 285,145 285,155" style="fill:#e07a2f;"/>
+
+  <path d="M500,150 L545,150" style="fill:none;stroke:#e07a2f;stroke-width:1.5;"/>
+  <polygon points="550,150 540,145 540,155" style="fill:#e07a2f;"/>
+
+  <!-- ========== RIGHT SECTION: Haptic VR ========== -->
+  <text x="666" y="55" style="font-family:Arial,sans-serif;font-size:12px;font-weight:bold;fill:#48cae4;text-anchor:middle;">Haptic VR</text>
+
+  <!-- Computer screen -->
+  <rect x="610" y="70" width="80" height="55" rx="3" style="fill:#0a1628;stroke:#2a5a7c;stroke-width:1.5;"/>
+  <rect x="637" y="125" width="26" height="8" style="fill:#2a5a7c;"/>
+  <rect x="627" y="133" width="46" height="4" rx="1" style="fill:#2a5a7c;"/>
+
+  <!-- 3D object on screen -->
+  <polygon points="650,85 670,78 670,103 650,110" style="fill:#1a6b8a;stroke:#48cae4;stroke-width:0.8;"/>
+  <polygon points="650,85 635,80 635,105 650,110" style="fill:#0e4d6b;stroke:#48cae4;stroke-width:0.8;"/>
+  <polygon points="635,80 650,73 670,78 650,85" style="fill:#2090b0;stroke:#48cae4;stroke-width:0.8;"/>
+
+  <!-- VR icon label -->
+  <text x="650" y="155" style="font-family:Arial,sans-serif;font-size:9px;fill:#90a4ae;text-anchor:middle;">VR Environment</text>
+
+  <!-- Haptic stylus device -->
+  <line x1="720" y1="100" x2="690" y2="170" style="stroke:#e07a2f;stroke-width:3;stroke-linecap:round;"/>
+  <circle cx="720" cy="100" r="4" style="fill:#e07a2f;"/>
+  <!-- Stylus base -->
+  <rect x="680" y="170" width="22" height="10" rx="2" style="fill:#3a3a4a;stroke:#e07a2f;stroke-width:1;"/>
+  <rect x="675" y="180" width="32" height="6" rx="2" style="fill:#3a3a4a;stroke:#e07a2f;stroke-width:1;"/>
+
+  <!-- Force feedback arrows -->
+  <path d="M715,105 C730,95 735,108 720,112" style="fill:none;stroke:#48cae4;stroke-width:1;stroke-dasharray:2,2;"/>
+  <text x="740" y="108" style="font-family:Arial,sans-serif;font-size:7px;fill:#48cae4;text-anchor:start;">Force</text>
+  <text x="740" y="117" style="font-family:Arial,sans-serif;font-size:7px;fill:#48cae4;text-anchor:start;">Feedback</text>
+
+  <!-- Stylus label -->
+  <text x="691" y="200" style="font-family:Arial,sans-serif;font-size:9px;fill:#90a4ae;text-anchor:middle;">Haptic Stylus</text>
+
+  <!-- ========== BOTTOM: Timeline ========== -->
+  <rect x="30" y="275" width="740" height="90" rx="6" style="fill:#0a1628;stroke:#1a3a5c;stroke-width:1;"/>
+
+  <!-- Timeline line -->
+  <line x1="60" y1="310" x2="740" y2="310" style="stroke:url(#timelineGrad);stroke-width:2;"/>
+
+  <!-- Timeline nodes -->
+  <!-- Node 1: Pin Array Prototype -->
+  <circle cx="130" cy="310" r="6" style="fill:#00b4d8;stroke:#48cae4;stroke-width:1.5;"/>
+  <text x="130" y="298" style="font-family:Arial,sans-serif;font-size:9px;font-weight:bold;fill:#48cae4;text-anchor:middle;">Pin Array Prototype</text>
+  <text x="130" y="330" style="font-family:Arial,sans-serif;font-size:8px;fill:#90a4ae;text-anchor:middle;">2008&#x2013;2010</text>
+
+  <!-- Arrow -->
+  <polygon points="215,310 205,305 205,315" style="fill:#48cae4;"/>
+
+  <!-- Node 2: Haptic Exploration -->
+  <circle cx="310" cy="310" r="6" style="fill:#00b4d8;stroke:#48cae4;stroke-width:1.5;"/>
+  <text x="310" y="298" style="font-family:Arial,sans-serif;font-size:9px;font-weight:bold;fill:#48cae4;text-anchor:middle;">Haptic Exploration</text>
+  <text x="310" y="330" style="font-family:Arial,sans-serif;font-size:8px;fill:#90a4ae;text-anchor:middle;">2009</text>
+
+  <!-- Arrow -->
+  <polygon points="400,310 390,305 390,315" style="fill:#48cae4;"/>
+
+  <!-- Node 3: VR Integration -->
+  <circle cx="490" cy="310" r="6" style="fill:#00b4d8;stroke:#48cae4;stroke-width:1.5;"/>
+  <text x="490" y="298" style="font-family:Arial,sans-serif;font-size:9px;font-weight:bold;fill:#48cae4;text-anchor:middle;">VR Integration</text>
+  <text x="490" y="330" style="font-family:Arial,sans-serif;font-size:8px;fill:#90a4ae;text-anchor:middle;">2012</text>
+
+  <!-- Arrow -->
+  <polygon points="580,310 570,305 570,315" style="fill:#e07a2f;"/>
+
+  <!-- Node 4: Project Frozen -->
+  <circle cx="660" cy="310" r="6" style="fill:#e07a2f;stroke:#ff9a3c;stroke-width:1.5;"/>
+  <text x="660" y="298" style="font-family:Arial,sans-serif;font-size:9px;font-weight:bold;fill:#e07a2f;text-anchor:middle;">Project Frozen</text>
+  <text x="660" y="330" style="font-family:Arial,sans-serif;font-size:8px;fill:#90a4ae;text-anchor:middle;">Paused</text>
+
+  <!-- Snowflake icon for frozen -->
+  <text x="660" y="352" style="font-family:Arial,sans-serif;font-size:14px;fill:#90a4ae;text-anchor:middle;">*</text>
+
+  <!-- Bottom label -->
+  <text x="400" y="358" style="font-family:Arial,sans-serif;font-size:8px;fill:#4a6a8a;text-anchor:middle;">Assistive technology for visually impaired users through haptic interfaces</text>
+
+</svg>

--- a/images/projects/hyclusvi_pipeline.svg
+++ b/images/projects/hyclusvi_pipeline.svg
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400" viewBox="0 0 800 400">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" style="stop-color:#0d1b2a"/>
+      <stop offset="100%" style="stop-color:#1b2d45"/>
+    </linearGradient>
+    <linearGradient id="specVNIR" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" style="stop-color:#7b2ff7"/>
+      <stop offset="30%" style="stop-color:#00b4d8"/>
+      <stop offset="60%" style="stop-color:#00cc44"/>
+      <stop offset="80%" style="stop-color:#ffcc00"/>
+      <stop offset="100%" style="stop-color:#ff3300"/>
+    </linearGradient>
+    <linearGradient id="specSWIR" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" style="stop-color:#ff3300"/>
+      <stop offset="50%" style="stop-color:#cc0000"/>
+      <stop offset="100%" style="stop-color:#660000"/>
+    </linearGradient>
+    <linearGradient id="boxGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" style="stop-color:#142840"/>
+      <stop offset="100%" style="stop-color:#0e1f35"/>
+    </linearGradient>
+    <linearGradient id="encGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" style="stop-color:#00b4d8"/>
+      <stop offset="100%" style="stop-color:#0077b6"/>
+    </linearGradient>
+    <linearGradient id="decGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" style="stop-color:#0077b6"/>
+      <stop offset="100%" style="stop-color:#00b4d8"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="400" fill="url(#bg)"/>
+
+  <!-- Title -->
+  <text x="400" y="24" style="font-family:Arial,sans-serif;font-size:15px;font-weight:bold;fill:#48cae4;text-anchor:middle;">HyClusVi &#x2014; Hyperspectral Clustering &amp; Visualization Pipeline</text>
+
+  <!-- ========== LEFT: Hyperspectral Acquisition ========== -->
+  <rect x="15" y="38" width="155" height="200" rx="6" style="fill:url(#boxGrad);stroke:#1a3a5c;stroke-width:1;"/>
+  <text x="92" y="56" style="font-family:Arial,sans-serif;font-size:10px;font-weight:bold;fill:#48cae4;text-anchor:middle;">Hyperspectral Acquisition</text>
+
+  <!-- VNIR Camera icon -->
+  <rect x="30" y="68" width="50" height="32" rx="4" style="fill:#1a3a5c;stroke:#00b4d8;stroke-width:1.2;"/>
+  <circle cx="55" cy="84" r="10" style="fill:#0a1628;stroke:#00b4d8;stroke-width:1;"/>
+  <circle cx="55" cy="84" r="5" style="fill:#00b4d8;opacity:0.3;"/>
+  <text x="55" y="114" style="font-family:Arial,sans-serif;font-size:8px;font-weight:bold;fill:#00b4d8;text-anchor:middle;">VNIR</text>
+  <text x="55" y="124" style="font-family:Arial,sans-serif;font-size:7px;fill:#7a9ab8;text-anchor:middle;">400&#x2013;1000nm</text>
+
+  <!-- SWIR Camera icon -->
+  <rect x="100" y="68" width="50" height="32" rx="4" style="fill:#1a3a5c;stroke:#e07a2f;stroke-width:1.2;"/>
+  <circle cx="125" cy="84" r="10" style="fill:#0a1628;stroke:#e07a2f;stroke-width:1;"/>
+  <circle cx="125" cy="84" r="5" style="fill:#e07a2f;opacity:0.3;"/>
+  <text x="125" y="114" style="font-family:Arial,sans-serif;font-size:8px;font-weight:bold;fill:#e07a2f;text-anchor:middle;">SWIR</text>
+  <text x="125" y="124" style="font-family:Arial,sans-serif;font-size:7px;fill:#7a9ab8;text-anchor:middle;">1000&#x2013;2500nm</text>
+
+  <!-- Spectral curve -->
+  <rect x="28" y="135" width="125" height="50" rx="3" style="fill:#0a1628;stroke:#1a3a5c;stroke-width:0.8;"/>
+  <!-- Axis -->
+  <line x1="38" y1="175" x2="143" y2="175" style="stroke:#3a5a7a;stroke-width:0.5;"/>
+  <line x1="38" y1="145" x2="38" y2="175" style="stroke:#3a5a7a;stroke-width:0.5;"/>
+  <!-- Spectral curve line -->
+  <path d="M40,168 C50,165 55,158 60,155 C65,150 68,148 72,152 C76,156 80,160 85,158 C90,155 95,148 100,145 C105,148 110,155 115,160 C120,163 125,165 130,162 C135,158 140,155 142,158" style="fill:none;stroke:#48cae4;stroke-width:1.5;"/>
+  <!-- Second curve for SWIR -->
+  <path d="M40,170 C50,168 55,165 60,163 C65,160 70,158 75,162 C80,165 85,168 90,166 C95,163 100,158 105,155 C110,158 115,163 120,167 C125,170 130,172 135,170 C140,168 142,166 142,168" style="fill:none;stroke:#e07a2f;stroke-width:1;opacity:0.7;"/>
+  <!-- Axis labels -->
+  <text x="90" y="184" style="font-family:Arial,sans-serif;font-size:6px;fill:#7a9ab8;text-anchor:middle;">Wavelength (nm)</text>
+  <text x="90" y="198" style="font-family:Arial,sans-serif;font-size:7px;fill:#7a9ab8;text-anchor:middle;">Reflectance Spectra</text>
+
+  <!-- Conveyor / sample illustration -->
+  <rect x="30" y="205" width="125" height="22" rx="3" style="fill:#1a3a5c;stroke:#2a5a7c;stroke-width:0.8;"/>
+  <text x="92" y="219" style="font-family:Arial,sans-serif;font-size:7px;fill:#90a4ae;text-anchor:middle;">Ore Sample on Conveyor</text>
+
+  <!-- Arrow to center -->
+  <polygon points="178,130 188,125 188,135" style="fill:#48cae4;"/>
+  <line x1="170" y1="130" x2="188" y2="130" style="stroke:#48cae4;stroke-width:1.5;"/>
+
+  <!-- ========== CENTER TOP: Preprocessing + Autoencoder ========== -->
+  <rect x="195" y="38" width="145" height="18" rx="4" style="fill:#1a3a5c;stroke:#48cae4;stroke-width:1;"/>
+  <text x="267" y="51" style="font-family:Arial,sans-serif;font-size:9px;font-weight:bold;fill:#48cae4;text-anchor:middle;">Preprocessing</text>
+
+  <!-- Arrow down -->
+  <line x1="267" y1="56" x2="267" y2="68" style="stroke:#48cae4;stroke-width:1;"/>
+  <polygon points="267,72 263,66 271,66" style="fill:#48cae4;"/>
+
+  <!-- Convolutional Autoencoder box -->
+  <rect x="195" y="75" width="310" height="100" rx="6" style="fill:url(#boxGrad);stroke:#1a3a5c;stroke-width:1;"/>
+  <text x="350" y="90" style="font-family:Arial,sans-serif;font-size:10px;font-weight:bold;fill:#48cae4;text-anchor:middle;">Convolutional Autoencoder</text>
+
+  <!-- Encoder layers -->
+  <text x="228" y="106" style="font-family:Arial,sans-serif;font-size:7px;fill:#90a4ae;text-anchor:middle;">Encoder</text>
+  <rect x="208" y="110" width="14" height="52" rx="2" style="fill:url(#encGrad);opacity:0.9;"/>
+  <text x="215" y="140" style="font-family:Arial,sans-serif;font-size:6px;fill:#fff;text-anchor:middle;writing-mode:tb;">128</text>
+  <rect x="228" y="116" width="14" height="40" rx="2" style="fill:url(#encGrad);opacity:0.8;"/>
+  <text x="235" y="140" style="font-family:Arial,sans-serif;font-size:6px;fill:#fff;text-anchor:middle;writing-mode:tb;">64</text>
+  <rect x="248" y="122" width="14" height="28" rx="2" style="fill:url(#encGrad);opacity:0.7;"/>
+  <text x="255" y="139" style="font-family:Arial,sans-serif;font-size:6px;fill:#fff;text-anchor:middle;writing-mode:tb;">32</text>
+  <rect x="268" y="127" width="14" height="18" rx="2" style="fill:url(#encGrad);opacity:0.6;"/>
+  <text x="275" y="139" style="font-family:Arial,sans-serif;font-size:6px;fill:#fff;text-anchor:middle;writing-mode:tb;">16</text>
+
+  <!-- Bottleneck (latent space) -->
+  <rect x="290" y="131" width="18" height="10" rx="3" style="fill:#e07a2f;stroke:#ff9a3c;stroke-width:1;"/>
+  <text x="299" y="139" style="font-family:Arial,sans-serif;font-size:6px;font-weight:bold;fill:#fff;text-anchor:middle;">4</text>
+  <text x="299" y="156" style="font-family:Arial,sans-serif;font-size:6px;fill:#e07a2f;text-anchor:middle;">Latent</text>
+
+  <!-- Decoder layers -->
+  <text x="370" y="106" style="font-family:Arial,sans-serif;font-size:7px;fill:#90a4ae;text-anchor:middle;">Decoder</text>
+  <rect x="316" y="127" width="14" height="18" rx="2" style="fill:url(#decGrad);opacity:0.6;"/>
+  <text x="323" y="139" style="font-family:Arial,sans-serif;font-size:6px;fill:#fff;text-anchor:middle;writing-mode:tb;">4</text>
+  <rect x="336" y="122" width="14" height="28" rx="2" style="fill:url(#decGrad);opacity:0.7;"/>
+  <text x="343" y="139" style="font-family:Arial,sans-serif;font-size:6px;fill:#fff;text-anchor:middle;writing-mode:tb;">16</text>
+  <rect x="356" y="116" width="14" height="40" rx="2" style="fill:url(#decGrad);opacity:0.8;"/>
+  <text x="363" y="140" style="font-family:Arial,sans-serif;font-size:6px;fill:#fff;text-anchor:middle;writing-mode:tb;">32</text>
+  <rect x="376" y="110" width="14" height="52" rx="2" style="fill:url(#decGrad);opacity:0.9;"/>
+  <text x="383" y="140" style="font-family:Arial,sans-serif;font-size:6px;fill:#fff;text-anchor:middle;writing-mode:tb;">64</text>
+  <rect x="396" y="110" width="14" height="52" rx="2" style="fill:url(#decGrad);opacity:1;"/>
+  <text x="403" y="140" style="font-family:Arial,sans-serif;font-size:6px;fill:#fff;text-anchor:middle;writing-mode:tb;">128</text>
+
+  <!-- Loss arrow -->
+  <path d="M415,136 C425,136 430,130 435,136 C440,142 445,136 455,136" style="fill:none;stroke:#e07a2f;stroke-width:1;stroke-dasharray:2,2;"/>
+  <text x="465" y="133" style="font-family:Arial,sans-serif;font-size:7px;fill:#e07a2f;text-anchor:start;">Reconstruction</text>
+  <text x="465" y="142" style="font-family:Arial,sans-serif;font-size:7px;fill:#e07a2f;text-anchor:start;">Loss</text>
+
+  <!-- ========== CENTER BOTTOM: Dimensionality Reduction ========== -->
+  <rect x="195" y="185" width="310" height="65" rx="6" style="fill:url(#boxGrad);stroke:#1a3a5c;stroke-width:1;"/>
+  <text x="350" y="200" style="font-family:Arial,sans-serif;font-size:10px;font-weight:bold;fill:#48cae4;text-anchor:middle;">Dimensionality Reduction</text>
+
+  <!-- Path 1: PCA + t-SNE -->
+  <rect x="215" y="208" width="110" height="18" rx="4" style="fill:#1a3a5c;stroke:#00b4d8;stroke-width:1;"/>
+  <text x="270" y="220" style="font-family:Arial,sans-serif;font-size:8px;fill:#00b4d8;text-anchor:middle;">PCA + t-SNE</text>
+
+  <!-- Path 2: Autoencoder + t-SNE -->
+  <rect x="345" y="208" width="140" height="18" rx="4" style="fill:#1a3a5c;stroke:#e07a2f;stroke-width:1;"/>
+  <text x="415" y="220" style="font-family:Arial,sans-serif;font-size:8px;fill:#e07a2f;text-anchor:middle;">Autoencoder + t-SNE</text>
+
+  <!-- Connection from AE latent to AE+tSNE -->
+  <path d="M299,165 L299,175 L415,175 L415,208" style="fill:none;stroke:#e07a2f;stroke-width:1;stroke-dasharray:3,2;"/>
+
+  <!-- Labels for paths -->
+  <text x="270" y="240" style="font-family:Arial,sans-serif;font-size:7px;fill:#7a9ab8;text-anchor:middle;">Baseline</text>
+  <text x="415" y="240" style="font-family:Arial,sans-serif;font-size:7px;fill:#7a9ab8;text-anchor:middle;">Proposed</text>
+
+  <!-- Arrow to right section -->
+  <polygon points="515,160 525,155 525,165" style="fill:#48cae4;"/>
+  <line x1="505" y1="160" x2="525" y2="160" style="stroke:#48cae4;stroke-width:1.5;"/>
+
+  <!-- ========== RIGHT: Visualization & Classification ========== -->
+  <rect x="535" y="38" width="250" height="215" rx="6" style="fill:url(#boxGrad);stroke:#1a3a5c;stroke-width:1;"/>
+  <text x="660" y="56" style="font-family:Arial,sans-serif;font-size:10px;font-weight:bold;fill:#48cae4;text-anchor:middle;">Visualization &amp; Classification</text>
+
+  <!-- Scatter plot area -->
+  <rect x="548" y="64" width="130" height="110" rx="3" style="fill:#0a1628;stroke:#1a3a5c;stroke-width:0.8;"/>
+  <!-- Axes -->
+  <line x1="560" y1="164" x2="670" y2="164" style="stroke:#3a5a7a;stroke-width:0.5;"/>
+  <line x1="560" y1="70" x2="560" y2="164" style="stroke:#3a5a7a;stroke-width:0.5;"/>
+  <text x="615" y="174" style="font-family:Arial,sans-serif;font-size:6px;fill:#7a9ab8;text-anchor:middle;">t-SNE dim 1</text>
+  <text x="553" y="120" style="font-family:Arial,sans-serif;font-size:6px;fill:#7a9ab8;text-anchor:middle;writing-mode:tb;">t-SNE dim 2</text>
+
+  <!-- Cluster 1 (blue) - grain size -->
+  <circle cx="585" cy="95" r="3" style="fill:#00b4d8;opacity:0.8;"/>
+  <circle cx="590" cy="100" r="3" style="fill:#00b4d8;opacity:0.8;"/>
+  <circle cx="582" cy="102" r="3" style="fill:#00b4d8;opacity:0.8;"/>
+  <circle cx="588" cy="90" r="3" style="fill:#00b4d8;opacity:0.8;"/>
+  <circle cx="595" cy="93" r="3" style="fill:#00b4d8;opacity:0.8;"/>
+  <circle cx="580" cy="88" r="3" style="fill:#00b4d8;opacity:0.8;"/>
+  <circle cx="592" cy="108" r="3" style="fill:#00b4d8;opacity:0.7;"/>
+
+  <!-- Cluster 2 (orange) -->
+  <circle cx="630" cy="130" r="3" style="fill:#e07a2f;opacity:0.8;"/>
+  <circle cx="638" cy="135" r="3" style="fill:#e07a2f;opacity:0.8;"/>
+  <circle cx="625" cy="138" r="3" style="fill:#e07a2f;opacity:0.8;"/>
+  <circle cx="635" cy="125" r="3" style="fill:#e07a2f;opacity:0.8;"/>
+  <circle cx="640" cy="140" r="3" style="fill:#e07a2f;opacity:0.8;"/>
+  <circle cx="622" cy="128" r="3" style="fill:#e07a2f;opacity:0.8;"/>
+  <circle cx="632" cy="142" r="3" style="fill:#e07a2f;opacity:0.7;"/>
+
+  <!-- Cluster 3 (green) -->
+  <circle cx="645" cy="85" r="3" style="fill:#2ecc71;opacity:0.8;"/>
+  <circle cx="650" cy="92" r="3" style="fill:#2ecc71;opacity:0.8;"/>
+  <circle cx="655" cy="80" r="3" style="fill:#2ecc71;opacity:0.8;"/>
+  <circle cx="640" cy="78" r="3" style="fill:#2ecc71;opacity:0.8;"/>
+  <circle cx="648" cy="88" r="3" style="fill:#2ecc71;opacity:0.8;"/>
+  <circle cx="658" cy="90" r="3" style="fill:#2ecc71;opacity:0.8;"/>
+
+  <!-- Cluster 4 (purple) - mixed -->
+  <circle cx="600" cy="145" r="3" style="fill:#9b59b6;opacity:0.8;"/>
+  <circle cx="608" cy="150" r="3" style="fill:#9b59b6;opacity:0.8;"/>
+  <circle cx="595" cy="152" r="3" style="fill:#9b59b6;opacity:0.8;"/>
+  <circle cx="605" cy="155" r="3" style="fill:#9b59b6;opacity:0.8;"/>
+  <circle cx="612" cy="148" r="3" style="fill:#9b59b6;opacity:0.7;"/>
+
+  <!-- Scatter plot label -->
+  <text x="613" y="184" style="font-family:Arial,sans-serif;font-size:8px;fill:#90a4ae;text-anchor:middle;">t-SNE 2D Projection</text>
+
+  <!-- Accuracy results box -->
+  <rect x="690" y="65" width="82" height="110" rx="4" style="fill:#0a1628;stroke:#1a3a5c;stroke-width:0.8;"/>
+  <text x="731" y="80" style="font-family:Arial,sans-serif;font-size:8px;font-weight:bold;fill:#48cae4;text-anchor:middle;">Accuracy</text>
+
+  <!-- Grain Size bar -->
+  <text x="698" y="98" style="font-family:Arial,sans-serif;font-size:7px;fill:#90a4ae;text-anchor:start;">Grain Size</text>
+  <rect x="698" y="102" width="65" height="8" rx="2" style="fill:#1a3a5c;"/>
+  <rect x="698" y="102" width="62" height="8" rx="2" style="fill:#2ecc71;"/>
+  <text x="764" y="109" style="font-family:Arial,sans-serif;font-size:7px;font-weight:bold;fill:#2ecc71;text-anchor:end;">95%</text>
+
+  <!-- Plant bar -->
+  <text x="698" y="125" style="font-family:Arial,sans-serif;font-size:7px;fill:#90a4ae;text-anchor:start;">Plant</text>
+  <rect x="698" y="129" width="65" height="8" rx="2" style="fill:#1a3a5c;"/>
+  <rect x="698" y="129" width="42" height="8" rx="2" style="fill:#e07a2f;"/>
+  <text x="764" y="136" style="font-family:Arial,sans-serif;font-size:7px;font-weight:bold;fill:#e07a2f;text-anchor:end;">65%</text>
+
+  <!-- Month bar -->
+  <text x="698" y="152" style="font-family:Arial,sans-serif;font-size:7px;fill:#90a4ae;text-anchor:start;">Month</text>
+  <rect x="698" y="156" width="65" height="8" rx="2" style="fill:#1a3a5c;"/>
+  <rect x="698" y="156" width="21" height="8" rx="2" style="fill:#e74c3c;"/>
+  <text x="764" y="163" style="font-family:Arial,sans-serif;font-size:7px;font-weight:bold;fill:#e74c3c;text-anchor:end;">33%</text>
+
+  <!-- Legend -->
+  <rect x="548" y="192" width="230" height="50" rx="4" style="fill:#0a1628;stroke:#1a3a5c;stroke-width:0.8;"/>
+  <text x="560" y="206" style="font-family:Arial,sans-serif;font-size:7px;fill:#90a4ae;text-anchor:start;">Legend:</text>
+  <circle cx="565" cy="216" r="3" style="fill:#00b4d8;"/>
+  <text x="573" y="219" style="font-family:Arial,sans-serif;font-size:7px;fill:#90a4ae;">Fine grain</text>
+  <circle cx="630" cy="216" r="3" style="fill:#e07a2f;"/>
+  <text x="638" y="219" style="font-family:Arial,sans-serif;font-size:7px;fill:#90a4ae;">Coarse grain</text>
+  <circle cx="710" cy="216" r="3" style="fill:#2ecc71;"/>
+  <text x="718" y="219" style="font-family:Arial,sans-serif;font-size:7px;fill:#90a4ae;">Plant A</text>
+  <circle cx="565" cy="230" r="3" style="fill:#9b59b6;"/>
+  <text x="573" y="233" style="font-family:Arial,sans-serif;font-size:7px;fill:#90a4ae;">Plant B</text>
+
+  <!-- ========== BOTTOM: Dataset info ========== -->
+  <rect x="15" y="265" width="770" height="40" rx="6" style="fill:#0a1628;stroke:#1a3a5c;stroke-width:1;"/>
+
+  <!-- Flow summary -->
+  <text x="400" y="281" style="font-family:Arial,sans-serif;font-size:9px;fill:#48cae4;text-anchor:middle;font-weight:bold;">Dataset: 72 samples &#x00D7; 3 plants &#x00D7; 2 grain sizes &#x00D7; 12 months</text>
+  <text x="400" y="296" style="font-family:Arial,sans-serif;font-size:8px;fill:#7a9ab8;text-anchor:middle;">Unsupervised clustering of hyperspectral imagery for mineral process characterization</text>
+
+  <!-- Bottom flow arrows with labels -->
+  <rect x="15" y="310" width="770" height="28" rx="6" style="fill:url(#boxGrad);stroke:#1a3a5c;stroke-width:0.8;"/>
+
+  <!-- Pipeline flow -->
+  <text x="70" y="328" style="font-family:Arial,sans-serif;font-size:8px;fill:#48cae4;text-anchor:middle;">HSI Capture</text>
+  <polygon points="125,325 135,320 135,330" style="fill:#3a5a7a;"/>
+  <text x="190" y="328" style="font-family:Arial,sans-serif;font-size:8px;fill:#48cae4;text-anchor:middle;">Calibration</text>
+  <polygon points="240,325 250,320 250,330" style="fill:#3a5a7a;"/>
+  <text x="310" y="328" style="font-family:Arial,sans-serif;font-size:8px;fill:#48cae4;text-anchor:middle;">Normalization</text>
+  <polygon points="370,325 380,320 380,330" style="fill:#3a5a7a;"/>
+  <text x="440" y="328" style="font-family:Arial,sans-serif;font-size:8px;fill:#e07a2f;text-anchor:middle;">Conv-AE</text>
+  <polygon points="480,325 490,320 490,330" style="fill:#3a5a7a;"/>
+  <text x="540" y="328" style="font-family:Arial,sans-serif;font-size:8px;fill:#e07a2f;text-anchor:middle;">t-SNE</text>
+  <polygon points="575,325 585,320 585,330" style="fill:#3a5a7a;"/>
+  <text x="640" y="328" style="font-family:Arial,sans-serif;font-size:8px;fill:#2ecc71;text-anchor:middle;">Clustering</text>
+  <polygon points="685,325 695,320 695,330" style="fill:#3a5a7a;"/>
+  <text x="740" y="328" style="font-family:Arial,sans-serif;font-size:8px;fill:#2ecc71;text-anchor:middle;">Evaluation</text>
+
+  <!-- Bottom credits -->
+  <text x="400" y="355" style="font-family:Arial,sans-serif;font-size:7px;fill:#3a5a7a;text-anchor:middle;">VNIR: Visible&#x2013;Near Infrared | SWIR: Short-Wave Infrared | Conv-AE: Convolutional Autoencoder | t-SNE: t-distributed Stochastic Neighbor Embedding</text>
+
+</svg>


### PR DESCRIPTION
## Summary
- 2 new SVG diagrams (FeelIT concept + HyClusVi pipeline)
- HyClusVi portfolio enriched with autoencoder architecture and HIDSAG connection
- 3 new talk entries: IEEE SAM Brazil 2016, AGU Fall Meeting 2021, Procemin Geomet 2022

Fixes #22 #24 #25

## Test plan
- [ ] SVGs render in portfolio pages
- [ ] Talk entries appear in talks listing
- [ ] HyClusVi autoencoder section renders correctly

---

@codex — Review only, zero execution! 6 files: 2 SVGs, 3 talks, 1 portfolio improvement. Check the SVG XML validity and talk metadata consistency. Desafio: encontra um erro nestes arquivos novos! 🇧🇷🇵🇹

🤖 Generated with [Claude Code](https://claude.com/claude-code)