### PR TITLE
Feat: Massive visual enrichment — 15 repo SVGs, 3 new rollings, 8 files enhanced

### DIFF
--- a/_posts/2019-09-20-MathGeo-SamplingStrategies.md
+++ b/_posts/2019-09-20-MathGeo-SamplingStrategies.md
@@ -16,6 +16,13 @@ A core piece of the doctoral puzzle
 
 This paper represents one of the central chapters of my PhD thesis, and seeing it finally published brings a deep sense of relief and pride. I started my doctoral studies in 2013, and this core result did not see print until 2019 -- six years of formulation, simulation, revision, and persistence. The reviewer cycles were particularly grueling: rounds of comments, months of waiting, resubmissions that required rethinking entire sections. There were moments where I genuinely wondered if the mathematical framework would survive peer review intact. When the acceptance finally came, the feeling was not celebration so much as quiet vindication -- the math had been validated by experts in the field, and the ideas I had been carrying for years were now part of the literature. This work was developed under the guidance of Prof. Jorge Silva and Prof. Julian Ortiz, whose complementary expertise in information theory and geostatistics made the interdisciplinary formulation possible. The work formalizes the optimal sampling problem for categorical spatial models using information-theoretic measures -- specifically, how to decide where to place new measurements so that uncertainty about the underlying geology is reduced as efficiently as possible.
 
+![Resolvability and sampling comparison](/images/rollings/owp_resolvability.svg)
+
+<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
+<strong style="color:#e07830;">Mutual information — the quantity we maximize:</strong><br/>
+I(X<sub>f</sub>; X<sup>f</sup>) = H(X<sup>f</sup>) − H(X<sup>f</sup> | X<sub>f</sub>)
+</div>
+
 The key contribution is a rigorous comparison between information-driven sampling strategies and the more conventional random or regular grid approaches. We show that by leveraging entropy and mutual information concepts from information theory, one can design sampling campaigns that extract significantly more knowledge per sample than standard approaches.
 
 This is not just a theoretical exercise. In mining and geosciences, every drill hole or measurement point has a real cost. Being able to demonstrate, formally, that an adaptive information-driven strategy outperforms brute-force regular grids means tangible savings and better geological models. The implementation of these methods, including the entropy estimators and simulation backends, is available as open-source code. [View the code on GitHub](https://github.com/fsantibanezleal/IDS_OWP).

--- a/_posts/2020-03-07-DoctoralDissertation.md
+++ b/_posts/2020-03-07-DoctoralDissertation.md
@@ -29,6 +29,13 @@ In this work, the formulation and experimental analysis of the Optimal Sensor Pl
 
 This work aims at formalizing the OSP problem for a given amount of available measurements. The characterization of the uncertainty is a central piece of this formalization -- connecting information theory with geostatistics in a way that had not been done before for categorical spatial models. The full dissertation is [available in the University of Chile repository](http://repositorio.uchile.cl/handle/2250/175050), and the code implementing the information-driven sampling framework is [open-sourced on GitHub](https://github.com/fsantibanezleal/IDS_OWP).
 
+![Information theory for spatial sampling](/images/rollings/owp_information_theory.svg)
+
+<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
+<strong style="color:#e07830;">Shannon entropy — maximum at uniform distribution (maximum uncertainty):</strong><br/>
+H(X) = −Σ p(x) log₂ p(x)
+</div>
+
 More details?
 ------
 

--- a/_posts/2025-12-20-CrusherWearPlatform.md
+++ b/_posts/2025-12-20-CrusherWearPlatform.md
@@ -18,6 +18,11 @@ The system starts with raw 3D laser scans of crusher liners -- point clouds with
 
 What made this project particularly interesting -- and particularly demanding -- is the dual deployment requirement. Mine sites often have limited or no internet connectivity, so the platform needed to work as a standalone desktop application (Streamlit and Dash packaged with PyInstaller). At the same time, a centralized web version (Next.js, FastAPI, PostgreSQL, Redis) was needed for multi-site management. Building for both contexts simultaneously meant thinking carefully about what logic could be shared and what had to be adapted. The challenge is not just technical; it is architectural. You have to design abstractions that are clean enough to work in a single-user offline context and robust enough to scale to multi-site, multi-user production. Getting that balance right was one of the most intellectually satisfying aspects of the project.
 
+<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
+<strong style="color:#e07830;">From 3D scan to wear profile:</strong><br/>
+Point cloud (x, y, z) → Cylindrical (r, θ, h) → Radial profile R(θ, h)
+</div>
+
 The infrastructure side was its own challenge: Docker Swarm orchestration, Traefik for routing, Ansible for automated provisioning. Going from a prototype running on a laptop to a production deployment with proper monitoring and backups is a journey that teaches you things no tutorial covers.
 
 There is a particular satisfaction in seeing raw 3D point clouds -- millions of noisy laser-scanned coordinates -- transform step by step into actionable maintenance decisions. The moment when an engineer looks at a wear forecast and says "we need to change those liners next week" based on data that started as a cloud of points in space -- that is the payoff. It makes the long hours of coordinate transformations and alignment algorithms feel worthwhile.

--- a/_posts/2026-03-20-SOFI-Chile.md
+++ b/_posts/2026-03-20-SOFI-Chile.md
@@ -10,6 +10,13 @@ tags:
 
 In 2012, I started working on Super-resolution Optical Fluctuation Imaging at SCIAN-Lab, Universidad de Chile, collaborating remotely with researchers at the III Physics Institute of the University of Gottingen in Germany. Working across continents and time zones with the Gottingen team was both challenging and exhilarating -- SOFI was a relatively new technique at the time, and there was limited local expertise in Chile to draw on. Every implementation decision, from the cumulant computation pipeline to the deconvolution strategy, required careful coordination through emails and video calls, often debugging numerical issues with a six-hour time difference. The goal was to implement SOFI from the ground up -- cumulant computation, synthetic quantum dot simulators, deconvolution -- and apply it to biological samples. After months of work, we achieved the first successful SOFI super-resolution imaging in Chile, resolving structures below the diffraction limit using nothing more than temporal statistics from blinking fluorescent emitters. The pride of being the first group in Chile to produce these results was immense -- it proved that cutting-edge computational optics could be done here, not just in European labs with larger budgets and established traditions in the field. That work contributed to a [publication at SPIE Photonics West](https://doi.org/10.1117/12.2006215), presenting the cumulant-based framework and validation results.
 
+![Cumulant vs moment decomposition](/images/rollings/sofi_cumulant_vs_moment.svg)
+
+<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
+<strong style="color:#e07830;">PSF narrowing:</strong><br/>
+σ<sub>n</sub> = σ / √n — at order 4, resolution doubles
+</div>
+
 From MATLAB folder to web app
 ======
 

--- a/_rollings/2009-08-20-01-haptic-collision.md
+++ b/_rollings/2009-08-20-01-haptic-collision.md
@@ -13,4 +13,10 @@ The octree collision detection is finally working properly with the PHANToM Omni
 
 The tricky part was getting the force computation fast enough — the haptic loop needs to run at 1 kHz or the force feedback feels unstable. The octree helps enormously by pruning the search space, but even so, every microsecond counts. The SAT triangle-triangle intersection test was the last piece — more robust than the vertex-proximity approach we had before.
 
-The surgeons who will eventually use the arthroscopic training simulator would never guess how much math goes into making a virtual knee feel right. [Haptic simulator on GitHub](https://github.com/fsantibanezleal/UDEC_Haptic_SIM).
+The surgeons who will eventually use the arthroscopic training simulator would never guess how much math goes into making a virtual knee feel right.
+
+![Octree spatial partitioning](/images/rollings/haptic_octree.svg)
+
+The octree subdivides 3D space into 8 children at each level — max_depth=4 means at most 4⁸ = 65,536 leaf nodes, but most are empty. Only leaves containing triangles are tested.
+
+[Haptic simulator on GitHub](https://github.com/fsantibanezleal/UDEC_Haptic_SIM).

--- a/_rollings/2010-06-05-01-optical-tweezers.md
+++ b/_rollings/2010-06-05-01-optical-tweezers.md
@@ -13,4 +13,8 @@ Working on the holographic optical tweezers system at CEFOP. The Gerchberg-Saxto
 
 The iterative convergence is mesmerizing. Each iteration gets closer to equalizing the intensity across all trap positions. The weighted version converges faster and distributes power more evenly.
 
-The lab smells like ozone from the laser and the room is always dark. I am learning a lot about Fourier optics and how phase modulation can shape light in ways I never imagined during my electronics courses at UdeC. [Optical tweezers on GitHub](https://github.com/fsantibanezleal/CEFOP_DinHot).
+The lab smells like ozone from the laser and the room is always dark. I am learning a lot about Fourier optics and how phase modulation can shape light in ways I never imagined during my electronics courses at UdeC.
+
+![Fourier optics and trap types](/images/rollings/dinhot_fourier_optics.svg)
+
+[Optical tweezers on GitHub](https://github.com/fsantibanezleal/CEFOP_DinHot).

--- a/_rollings/2012-08-15-01-sofi-first-results.md
+++ b/_rollings/2012-08-15-01-sofi-first-results.md
@@ -13,4 +13,14 @@ After weeks of debugging MATLAB code and calibrating the microscope, we got the 
 
 This is apparently the first time anyone has done this in Chile. The collaboration with the group in Göttingen has been essential — they have years of experience with the technique and helped us avoid several pitfalls with the cumulant computation.
 
-Still a lot to do. Higher orders (3rd, 4th) should give even better resolution, but the noise gets worse. Need more frames. [SOFI project on GitHub](https://github.com/fsantibanezleal/FASL_SOFI_QDOTS).
+Still a lot to do. Higher orders (3rd, 4th) should give even better resolution, but the noise gets worse. Need more frames.
+
+![SOFI vs conventional microscopy](/images/rollings/sofi_vs_palm.svg)
+
+<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
+<strong style="color:#e07830;">2nd-order cumulant:</strong><br/>
+&kappa;&#x2082; = &langle;&delta;F(t) &middot; &delta;F(t+&tau;)&rangle;<br/>
+<em>Resolution improvement: &radic;2 &asymp; 1.41&times;</em>
+</div>
+
+[SOFI project on GitHub](https://github.com/fsantibanezleal/FASL_SOFI_QDOTS).

--- a/_rollings/2015-03-10-01-entropy-sampling.md
+++ b/_rollings/2015-03-10-01-entropy-sampling.md
@@ -13,4 +13,14 @@ The adaptive entropy sampling algorithm is starting to converge to something use
 
 Spent the last month implementing the conditional entropy estimator from scratch in MATLAB. The multiple-point statistics backend is slow but it works. Comparing against regular grids and random sampling, the information-theoretic approach consistently recovers the field better with fewer samples. The (1-1/e) approximation guarantee from the submodularity property is elegant — theory and practice agreeing for once.
 
-Professor Silva's guidance on the information-theoretic formulation has been invaluable. This might actually become a publishable framework. [Sampling code on GitHub](https://github.com/fsantibanezleal/IDS_OWP).
+Professor Silva's guidance on the information-theoretic formulation has been invaluable. This might actually become a publishable framework.
+
+![Information theory concepts](/images/rollings/owp_information_theory.svg)
+
+<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
+<strong style="color:#e07830;">Conditional entropy:</strong><br/>
+H(X|Y) = H(X,Y) &minus; H(Y)<br/>
+<em>Posterior uncertainty decreases as we sample</em>
+</div>
+
+[Sampling code on GitHub](https://github.com/fsantibanezleal/IDS_OWP).

--- a/_rollings/2026-03-28-02-bug-fixing-across-repos.md
+++ b/_rollings/2026-03-28-02-bug-fixing-across-repos.md
@@ -1,0 +1,27 @@
+---
+title: 'Eight Repos, One Night'
+date: 2026-03-28
+permalink: /rollings/2026/03/bug-fixing-across-repos/
+tags:
+  - Bug Fixing
+  - Open Source
+  - Testing
+---
+
+Fixing bugs in 8 repos simultaneously is like being a doctor treating 8 patients with different conditions but the same underlying immune system. They all share the same architectural spine — FastAPI + WebSocket + NumPy — but each one lives in a completely different scientific domain. The haptic simulator speaks in triangles and force vectors. The optical tweezers think in Fourier transforms and phase masks. The well placement optimizer dreams of Darcy flow and permeability fields. And yet, a bug in one teaches you something about all the others.
+
+Tonight was one of those nights. It started with a collision detection bug in the Cellular Potts Model — the contour extent was being compared against the base_radius when it should have been compared against the actual cell boundary. A subtle difference that only shows up when cells elongate during division. Speaking of division, Hertwig's rule for choosing the division axis had a sign error that made cells divide perpendicular to their longest axis instead of along it. Biology reversed.
+
+![Cell model with Gaussian filopodia](/images/rollings/cpm_cell_model.svg)
+
+<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
+<strong style="color:#e07830;">Hamiltonian energy:</strong><br/>
+H = &lambda;<sub>A</sub>(A &minus; A<sub>target</sub>)&sup2; + &lambda;<sub>P</sub>(P &minus; P<sub>target</sub>)&sup2;<br/>
+&lambda;<sub>A</sub> = 0.1, &lambda;<sub>P</sub> = 0.05
+</div>
+
+The contour extent bug reminded me of the octree bounding box logic in the haptic simulator — same class of error, different geometry. You define a spatial boundary, but when the object deforms or moves, the boundary does not update correctly. In the CPM it was a growing cell; in the haptic sim it was a stylus moving near the edge of a subdivided region. Same mistake, different universe.
+
+And then, while fixing a numerical stability issue in the optical tweezers intensity normalization, I realized the Darcy solver in the well placement code had a nearly identical problem — dividing by a sum that could be zero when all weights collapsed. Two domains, two solvers, one floating-point trap.
+
+The shared patterns make it possible to carry fixes across. The different domains make it interesting. Eight repos, one night, and a lot of coffee.

--- a/_rollings/2026-03-28-03-helmholtz-reciprocity.md
+++ b/_rollings/2026-03-28-03-helmholtz-reciprocity.md
@@ -1,0 +1,31 @@
+---
+title: 'Light Goes Both Ways'
+date: 2026-03-28
+permalink: /rollings/2026/03/helmholtz-reciprocity/
+tags:
+  - Optics
+  - Dual Photography
+  - Helmholtz
+  - SVD
+---
+
+There is something philosophically satisfying about the idea that every observation contains, embedded within it, the reverse observation. Helmholtz saw this in 1856. Light paths are reversible — if a photon can travel from point A to point B through a scene, bouncing off surfaces and scattering through media, then a photon can travel the exact same path from B back to A. The physics does not care about direction.
+
+Dual photography takes this principle and turns it into a computational tool. You project structured patterns from a projector onto a scene and capture the result with a camera. Each pixel in the projector illuminates the scene, and each pixel in the camera records the aggregate response. The entire relationship between projector pixels and camera pixels is captured in a transport matrix T.
+
+![Helmholtz reciprocity](/images/rollings/dual_helmholtz.svg)
+
+<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
+<strong style="color:#e07830;">Transport matrix:</strong><br/>
+c = T &middot; p &nbsp;&nbsp;(forward)<br/>
+p' = T<sup>T</sup> &middot; c &nbsp;&nbsp;(dual)<br/>
+<em>The transpose is all you need</em>
+</div>
+
+The forward image is c = T*p, where p is the projector pattern and c is the camera capture. The dual image — what the scene would look like if the camera were the light source and the projector were the sensor — is simply p' = T^T * c. The transpose is all you need. Helmholtz reciprocity guarantees that this transposed matrix is physically meaningful.
+
+But the transport matrix is large and measuring it naively requires as many captures as there are projector pixels. This is where the SVD becomes essential. Decomposing T = USV^T lets you approximate the matrix with far fewer measurements, and it also enables relighting — synthesizing images under novel illumination conditions without physically changing the light.
+
+The low-rank structure of most real scenes means that a handful of singular values capture most of the transport. The rest is noise and high-frequency inter-reflections that rarely matter perceptually.
+
+I keep coming back to this project because it sits at the intersection of linear algebra and physical optics in a way that feels almost too clean. The math works because the physics is symmetric, and the physics is symmetric because... well, that is a deeper question. [Dual Photography project](https://github.com/fsantibanezleal/FASL_Coding_DualFotography).

--- a/_rollings/2026-03-28-04-robot-workspace.md
+++ b/_rollings/2026-03-28-04-robot-workspace.md
@@ -1,0 +1,29 @@
+---
+title: 'Where Can the Robot Reach?'
+date: 2026-03-28
+permalink: /rollings/2026/03/robot-workspace/
+tags:
+  - Robotics
+  - Kinematics
+  - Workspace
+---
+
+The Scorbot III has 5 degrees of freedom, and you might think that means it can reach anywhere in a sphere around its base. It cannot. The reachable workspace is a complex torus-like volume carved out by joint limits, link lengths, and the coupling between joints. Some orientations are simply unreachable at certain positions. The workspace is not a sphere — it is a strange, asymmetric solid that you only truly understand by sweeping through all joint combinations and plotting the result.
+
+![Robot workspace and DH frames](/images/rollings/robot_workspace.svg)
+
+For the robotic writer, the letters are arranged on a circular arc at radius 280mm from the base, the writing line sits at 300mm, and the safe travel height is 75mm above the surface. These numbers were not chosen for aesthetics — they were chosen because they fall inside the reachable workspace for the approach angle we need.
+
+The approach angle of -70 degrees (near-vertical) was the result of a long search. You want the pen to come down as close to perpendicular as possible for clean strokes, but a truly vertical approach at the required distance pushes joint 3 past its limit. So -70 degrees it is — a compromise between calligraphy quality and kinematic feasibility.
+
+![Denavit-Hartenberg reference frames](/images/rollings/robot_dh_frames.svg)
+
+<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
+<strong style="color:#e07830;">Forward kinematics chain:</strong><br/>
+T<sub>0</sub><sup>5</sup> = T<sub>0</sub><sup>1</sup> &middot; T<sub>1</sub><sup>2</sup> &middot; T<sub>2</sub><sup>3</sup> &middot; T<sub>3</sub><sup>4</sup> &middot; T<sub>4</sub><sup>5</sup><br/>
+<em>5 transformations compose the end-effector pose</em>
+</div>
+
+The Denavit-Hartenberg convention gives you a systematic way to assign coordinate frames to each joint and compute the full chain. Each 4x4 homogeneous transformation encodes a rotation and a translation, and the product of all five gives you the end-effector position and orientation in the base frame. Inverse kinematics — going from a desired pen position back to joint angles — is where the real pain lives, especially with 5 DOF where you have to sacrifice one degree of orientation freedom.
+
+Every letter the robot writes is a sequence of these inverse kinematics solutions, interpolated smoothly so the pen does not jerk. The workspace analysis tells you which letters are even possible. The rest is just path planning. [Robotic Writer](https://github.com/fsantibanezleal/Udec_Robotic_Writer).

--- a/images/rollings/cpm_cell_model.svg
+++ b/images/rollings/cpm_cell_model.svg
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600">
+  <defs>
+    <marker id="arrowTip" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#e94560"/>
+    </marker>
+    <marker id="arrowTipBlue" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#58a6ff"/>
+    </marker>
+    <marker id="arrowTipGold" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#ffd700"/>
+    </marker>
+    <radialGradient id="cellGrad" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" style="stop-color:#1a3a4a;stop-opacity:0.6"/>
+      <stop offset="100%" style="stop-color:#0a1520;stop-opacity:0.3"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="600" height="600" fill="#f8f9fa" rx="4"/>
+
+  <!-- Title -->
+  <text x="300" y="32" text-anchor="middle" fill="#1a1a2e" font-family="Arial, sans-serif" font-size="17" font-weight="bold">Gaussian Filopodia Cell Model</text>
+  <text x="300" y="52" text-anchor="middle" fill="#555" font-family="Arial, sans-serif" font-size="12">R(theta) = max_j { R0 + A_j * exp( -(theta - theta0_j)^2 / (2 W_j^2) ) }</text>
+
+  <!-- Coordinate system center -->
+  <!-- Cell center at (280, 310) -->
+
+  <!-- Base radius circle (dashed) -->
+  <circle cx="280" cy="310" r="110" fill="url(#cellGrad)" stroke="#888" stroke-width="1.5" stroke-dasharray="6,4"/>
+  <text x="280" y="445" text-anchor="middle" fill="#666" font-family="Arial, sans-serif" font-size="11">Base circle (R0)</text>
+
+  <!-- R0 radius label line -->
+  <line x1="280" y1="310" x2="390" y2="310" stroke="#888" stroke-width="1" stroke-dasharray="3,2"/>
+  <text x="340" y="303" text-anchor="middle" fill="#e94560" font-family="Arial, sans-serif" font-size="13" font-weight="bold">R0</text>
+
+  <!-- Cell center dot -->
+  <circle cx="280" cy="310" r="4" fill="#e94560"/>
+  <text x="268" y="330" text-anchor="end" fill="#e94560" font-family="Arial, sans-serif" font-size="11">center</text>
+
+  <!-- Filopodium 1 (top-right, angle ~40 deg) -->
+  <!-- Gaussian bump extending from base radius -->
+  <path d="M 364,228 C 370,215 385,195 400,185 C 415,195 420,215 416,228" fill="none" stroke="#4ecca3" stroke-width="2.5"/>
+  <!-- A label (amplitude) -->
+  <line x1="400" y1="228" x2="400" y2="185" stroke="#4ecca3" stroke-width="1" stroke-dasharray="3,2"/>
+  <text x="415" y="205" fill="#4ecca3" font-family="Arial, sans-serif" font-size="13" font-weight="bold">A</text>
+  <!-- W label (width) -->
+  <line x1="370" y1="220" x2="420" y2="220" stroke="#58a6ff" stroke-width="1" marker-start="url(#arrowTipBlue)" marker-end="url(#arrowTipBlue)"/>
+  <text x="395" y="237" fill="#58a6ff" font-family="Arial, sans-serif" font-size="12" font-weight="bold">W</text>
+
+  <!-- Filopodium 2 (upper-left, angle ~150 deg) -->
+  <path d="M 185,240 C 170,230 155,215 150,200 C 140,210 137,230 140,245" fill="none" stroke="#4ecca3" stroke-width="2.5"/>
+
+  <!-- Filopodium 3 (lower-left, angle ~210 deg) -->
+  <path d="M 175,380 C 160,390 140,400 130,410 C 140,420 160,418 172,408" fill="none" stroke="#4ecca3" stroke-width="2.5"/>
+
+  <!-- Filopodium 4 (lower-right, angle ~320 deg) -->
+  <path d="M 380,388 C 395,400 410,415 420,425 C 428,415 425,395 415,383" fill="none" stroke="#4ecca3" stroke-width="2.5"/>
+
+  <!-- Resulting envelope contour (the actual cell shape) -->
+  <path d="M 390,310 C 395,290 400,260 416,228 C 420,215 415,195 400,185 C 385,195 370,215 364,228 C 350,250 330,230 310,218 C 290,210 260,215 240,222 C 220,230 200,238 185,240 C 170,230 155,215 150,200 C 140,210 137,230 140,245 C 143,260 155,275 170,290 C 175,300 172,320 170,340 C 168,360 170,375 175,380 C 160,390 140,400 130,410 C 140,420 160,418 172,408 C 185,398 200,395 220,392 C 245,388 270,395 300,398 C 330,400 355,395 380,388 C 395,400 410,415 420,425 C 428,415 425,395 415,383 C 405,370 398,350 395,330 C 393,320 392,315 390,310 Z" fill="none" stroke="#4ecca3" stroke-width="2" stroke-opacity="0.5"/>
+
+  <!-- theta0 angle arc for filopodium 1 -->
+  <path d="M 320,310 A 40,40 0 0,0 306,278" fill="none" stroke="#f0883e" stroke-width="1.5"/>
+  <text x="330" y="283" fill="#f0883e" font-family="Arial, sans-serif" font-size="13" font-weight="bold">theta0</text>
+
+  <!-- Angle reference line (horizontal) -->
+  <line x1="280" y1="310" x2="330" y2="310" stroke="#f0883e" stroke-width="1" stroke-dasharray="2,2"/>
+  <!-- Angle line to filopodium 1 -->
+  <line x1="280" y1="310" x2="330" y2="275" stroke="#f0883e" stroke-width="1" stroke-dasharray="2,2"/>
+
+  <!-- Velocity arrow -->
+  <line x1="280" y1="310" x2="340" y2="250" stroke="#ffd700" stroke-width="2.5" marker-end="url(#arrowTipGold)"/>
+  <text x="345" y="265" fill="#ffd700" font-family="Arial, sans-serif" font-size="13" font-weight="bold">v</text>
+
+  <!-- Legend box -->
+  <rect x="20" y="475" width="560" height="110" rx="6" fill="#fff" stroke="#ddd" stroke-width="1"/>
+  <text x="300" y="498" text-anchor="middle" fill="#1a1a2e" font-family="Arial, sans-serif" font-size="13" font-weight="bold">Parameters</text>
+
+  <circle cx="45" cy="520" r="5" fill="#e94560"/>
+  <text x="60" y="524" fill="#333" font-family="Arial, sans-serif" font-size="11">R0 -- Base radius of the cell body</text>
+
+  <circle cx="45" cy="542" r="5" fill="#4ecca3"/>
+  <text x="60" y="546" fill="#333" font-family="Arial, sans-serif" font-size="11">A -- Filopodium amplitude (protrusion height above R0)</text>
+
+  <circle cx="45" cy="564" r="5" fill="#58a6ff"/>
+  <text x="60" y="568" fill="#333" font-family="Arial, sans-serif" font-size="11">W -- Gaussian width (angular spread of the filopodium)</text>
+
+  <circle cx="350" cy="520" r="5" fill="#f0883e"/>
+  <text x="365" y="524" fill="#333" font-family="Arial, sans-serif" font-size="11">theta0 -- Angular position of filopodium center</text>
+
+  <circle cx="350" cy="542" r="5" fill="#ffd700"/>
+  <text x="365" y="546" fill="#333" font-family="Arial, sans-serif" font-size="11">v -- Velocity from shape asymmetry</text>
+
+  <line x1="350" y1="564" x2="370" y2="564" stroke="#888" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <text x="380" y="568" fill="#333" font-family="Arial, sans-serif" font-size="11">Dashed circle -- Base radius boundary</text>
+</svg>

--- a/images/rollings/cpm_durotaxis.svg
+++ b/images/rollings/cpm_durotaxis.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="500" viewBox="0 0 600 500">
+  <defs>
+    <marker id="arrMagenta" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#ff44cc"/>
+    </marker>
+    <marker id="arrOrange" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#ff8844"/>
+    </marker>
+    <marker id="arrCyanD" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#00ddff"/>
+    </marker>
+    <marker id="arrGreenD" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#44ee88"/>
+    </marker>
+    <linearGradient id="stiffnessGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#223344;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#5588aa;stop-opacity:1"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background with stiffness gradient -->
+  <rect width="600" height="500" fill="#1a1a2e" rx="8"/>
+
+  <!-- Stiffness gradient band -->
+  <rect x="40" y="60" width="520" height="380" fill="url(#stiffnessGrad)" rx="6" opacity="0.4"/>
+  <text x="60" y="85" fill="#6688aa" font-family="Arial, sans-serif" font-size="11">SOFT</text>
+  <text x="510" y="85" fill="#99ccdd" font-family="Arial, sans-serif" font-size="11">STIFF</text>
+
+  <!-- Title -->
+  <text x="300" y="35" text-anchor="middle" fill="#ffffff" font-family="Arial, sans-serif" font-size="18" font-weight="bold">Durotaxis: Sinusoidal Torque Model</text>
+
+  <!-- Stiffness gradient arrow -->
+  <line x1="120" y1="440" x2="480" y2="440" stroke="#ff44cc" stroke-width="2.5" marker-end="url(#arrMagenta)"/>
+  <text x="300" y="470" text-anchor="middle" fill="#ff44cc" font-family="Arial, sans-serif" font-size="14" font-weight="bold">grad E (stiffness gradient)</text>
+
+  <!-- Cell body -->
+  <circle cx="280" cy="250" r="70" fill="none" stroke="#8899bb" stroke-width="2.5"/>
+  <circle cx="280" cy="250" r="3" fill="#ffcc00"/>
+  <text x="268" y="243" fill="#ffcc00" font-family="Arial, sans-serif" font-size="10">cell</text>
+
+  <!-- Filopodium 1: pointing RIGHT (aligned with gradient) - NO torque -->
+  <line x1="280" y1="250" x2="390" y2="250" stroke="#44ee88" stroke-width="2.5" marker-end="url(#arrGreenD)"/>
+  <text x="395" y="246" fill="#44ee88" font-family="Arial, sans-serif" font-size="11">F1: aligned</text>
+  <text x="395" y="260" fill="#44ee88" font-family="Arial, sans-serif" font-size="10">torque ~ 0</text>
+
+  <!-- Filopodium 2: pointing UP (perpendicular) - MAXIMUM torque clockwise toward right -->
+  <line x1="280" y1="250" x2="280" y2="145" stroke="#44ee88" stroke-width="2.5" marker-end="url(#arrGreenD)"/>
+  <text x="290" y="138" fill="#44ee88" font-family="Arial, sans-serif" font-size="11">F2: perpendicular</text>
+  <!-- Torque arc arrow (clockwise, toward right) -->
+  <path d="M 280 160 A 30 30 0 0 1 310 175" fill="none" stroke="#ff8844" stroke-width="2.5" marker-end="url(#arrOrange)"/>
+  <text x="315" y="158" fill="#ff8844" font-family="Arial, sans-serif" font-size="10" font-weight="bold">MAX torque</text>
+
+  <!-- Filopodium 3: pointing LEFT (anti-aligned) - NO torque (sin(pi)=0, unstable equilibrium) -->
+  <line x1="280" y1="250" x2="175" y2="250" stroke="#44ee88" stroke-width="2" marker-end="url(#arrGreenD)"/>
+  <text x="100" y="246" fill="#44ee88" font-family="Arial, sans-serif" font-size="11">F3: anti-aligned</text>
+  <text x="110" y="260" fill="#ff8844" font-family="Arial, sans-serif" font-size="10">unstable: sin(pi)=0</text>
+
+  <!-- Filopodium 4: pointing DOWN-LEFT (oblique) - medium torque -->
+  <line x1="280" y1="250" x2="210" y2="340" stroke="#44ee88" stroke-width="2" marker-end="url(#arrGreenD)"/>
+  <text x="140" y="350" fill="#44ee88" font-family="Arial, sans-serif" font-size="11">F4: oblique</text>
+  <!-- Torque arc arrow (counterclockwise, toward right) -->
+  <path d="M 225 325 A 25 25 0 0 0 240 350" fill="none" stroke="#ff8844" stroke-width="2.5" marker-end="url(#arrOrange)"/>
+  <text x="245" y="365" fill="#ff8844" font-family="Arial, sans-serif" font-size="10">medium torque</text>
+
+  <!-- Formula box -->
+  <rect x="50" y="390" width="500" height="35" fill="#111122" rx="4" stroke="#333355" stroke-width="1"/>
+  <text x="300" y="412" text-anchor="middle" fill="#ccccee" font-family="monospace" font-size="13">d_theta_duro = alpha * |grad E| * sin(theta_gradient - theta_j)</text>
+
+  <!-- Legend -->
+  <line x1="50" y1="105" x2="75" y2="105" stroke="#44ee88" stroke-width="2.5"/>
+  <text x="80" y="109" fill="#aaaacc" font-family="Arial, sans-serif" font-size="11">filopodium direction</text>
+  <path d="M 50 125 A 10 10 0 0 1 70 125" fill="none" stroke="#ff8844" stroke-width="2.5"/>
+  <text x="80" y="129" fill="#aaaacc" font-family="Arial, sans-serif" font-size="11">durotactic torque</text>
+</svg>

--- a/images/rollings/dinhot_fourier_optics.svg
+++ b/images/rollings/dinhot_fourier_optics.svg
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="500" viewBox="0 0 800 500">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, sans-serif; }
+    </style>
+    <!-- Arrow marker -->
+    <marker id="arrowW" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M 0 0 L 8 3 L 0 6 Z" fill="#e6edf3"/>
+    </marker>
+    <marker id="arrowB" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M 0 0 L 8 3 L 0 6 Z" fill="#58a6ff"/>
+    </marker>
+    <!-- Laser beam gradient -->
+    <linearGradient id="laserGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#da3633" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#da3633" stop-opacity="0.3"/>
+    </linearGradient>
+    <!-- Lens gradient -->
+    <linearGradient id="lensGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#58a6ff" stop-opacity="0.1"/>
+      <stop offset="50%" stop-color="#58a6ff" stop-opacity="0.4"/>
+      <stop offset="100%" stop-color="#58a6ff" stop-opacity="0.1"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="500" fill="#0d1117"/>
+
+  <!-- Title -->
+  <text x="400" y="30" fill="#e6edf3" font-size="16" font-weight="bold" text-anchor="middle">4f Optical System: SLM to Focal Plane</text>
+
+  <!-- Optical axis -->
+  <line x1="30" y1="200" x2="770" y2="200" stroke="#30363d" stroke-width="1" stroke-dasharray="4,4"/>
+  <text x="780" y="204" fill="#30363d" font-size="9">z</text>
+
+  <!-- Laser source -->
+  <rect x="40" y="170" width="50" height="60" rx="4" fill="#161b22" stroke="#da3633" stroke-width="1.5"/>
+  <text x="65" y="195" fill="#da3633" font-size="10" text-anchor="middle">Laser</text>
+  <text x="65" y="207" fill="#da3633" font-size="8" text-anchor="middle">632 nm</text>
+  <!-- Beam from laser to SLM -->
+  <rect x="90" y="190" width="120" height="20" fill="url(#laserGrad)" opacity="0.3"/>
+  <line x1="90" y1="190" x2="210" y2="190" stroke="#da3633" stroke-width="1" opacity="0.6"/>
+  <line x1="90" y1="210" x2="210" y2="210" stroke="#da3633" stroke-width="1" opacity="0.6"/>
+
+  <!-- SLM -->
+  <rect x="210" y="140" width="30" height="120" rx="3" fill="#161b22" stroke="#f0883e" stroke-width="1.5"/>
+  <!-- SLM pixel pattern -->
+  <rect x="215" y="148" width="20" height="8" fill="#f0883e" opacity="0.3"/>
+  <rect x="215" y="160" width="20" height="8" fill="#f0883e" opacity="0.5"/>
+  <rect x="215" y="172" width="20" height="8" fill="#f0883e" opacity="0.2"/>
+  <rect x="215" y="184" width="20" height="8" fill="#f0883e" opacity="0.6"/>
+  <rect x="215" y="196" width="20" height="8" fill="#f0883e" opacity="0.4"/>
+  <rect x="215" y="208" width="20" height="8" fill="#f0883e" opacity="0.7"/>
+  <rect x="215" y="220" width="20" height="8" fill="#f0883e" opacity="0.3"/>
+  <rect x="215" y="232" width="20" height="8" fill="#f0883e" opacity="0.5"/>
+  <text x="225" y="135" fill="#f0883e" font-size="11" font-weight="bold" text-anchor="middle">SLM</text>
+  <text x="225" y="275" fill="#8b949e" font-size="9" text-anchor="middle">phi(x,y)</text>
+
+  <!-- Phase-modulated beam (diverging rays) -->
+  <line x1="240" y1="160" x2="390" y2="150" stroke="#da3633" stroke-width="0.8" opacity="0.4"/>
+  <line x1="240" y1="175" x2="390" y2="170" stroke="#da3633" stroke-width="0.8" opacity="0.4"/>
+  <line x1="240" y1="190" x2="390" y2="190" stroke="#da3633" stroke-width="0.8" opacity="0.4"/>
+  <line x1="240" y1="205" x2="390" y2="210" stroke="#da3633" stroke-width="0.8" opacity="0.4"/>
+  <line x1="240" y1="225" x2="390" y2="240" stroke="#da3633" stroke-width="0.8" opacity="0.4"/>
+
+  <!-- Fourier Lens -->
+  <ellipse cx="400" cy="200" rx="12" ry="70" fill="url(#lensGrad)" stroke="#58a6ff" stroke-width="1.5"/>
+  <text x="400" y="125" fill="#58a6ff" font-size="11" font-weight="bold" text-anchor="middle">Lens (f)</text>
+
+  <!-- Converging rays to focal plane -->
+  <line x1="412" y1="150" x2="560" y2="185" stroke="#da3633" stroke-width="0.8" opacity="0.4"/>
+  <line x1="412" y1="170" x2="560" y2="190" stroke="#da3633" stroke-width="0.8" opacity="0.4"/>
+  <line x1="412" y1="190" x2="560" y2="195" stroke="#da3633" stroke-width="0.8" opacity="0.4"/>
+  <line x1="412" y1="210" x2="560" y2="200" stroke="#da3633" stroke-width="0.8" opacity="0.4"/>
+  <line x1="412" y1="240" x2="560" y2="210" stroke="#da3633" stroke-width="0.8" opacity="0.4"/>
+
+  <!-- Focal plane -->
+  <line x1="560" y1="140" x2="560" y2="260" stroke="#3fb950" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="560" y="135" fill="#3fb950" font-size="11" font-weight="bold" text-anchor="middle">Focal Plane</text>
+
+  <!-- Trap spots in focal plane -->
+  <circle cx="560" cy="185" r="4" fill="#3fb950" opacity="0.9"/>
+  <circle cx="560" cy="200" r="4" fill="#3fb950" opacity="0.9"/>
+  <circle cx="560" cy="215" r="4" fill="#3fb950" opacity="0.9"/>
+  <text x="560" y="275" fill="#8b949e" font-size="9" text-anchor="middle">I(u,v)</text>
+
+  <!-- Microscope objective -->
+  <ellipse cx="630" cy="200" rx="10" ry="50" fill="url(#lensGrad)" stroke="#58a6ff" stroke-width="1.5"/>
+  <text x="630" y="145" fill="#58a6ff" font-size="9" text-anchor="middle">Objective</text>
+
+  <!-- Sample plane -->
+  <line x1="720" y1="160" x2="720" y2="240" stroke="#3fb950" stroke-width="2"/>
+  <text x="720" y="155" fill="#3fb950" font-size="10" font-weight="bold" text-anchor="middle">Sample</text>
+  <!-- Trapped particles -->
+  <circle cx="720" cy="185" r="5" fill="none" stroke="#e6edf3" stroke-width="1"/>
+  <circle cx="720" cy="200" r="5" fill="none" stroke="#e6edf3" stroke-width="1"/>
+  <circle cx="720" cy="215" r="5" fill="none" stroke="#e6edf3" stroke-width="1"/>
+  <circle cx="720" cy="185" r="2" fill="#e6edf3" opacity="0.6"/>
+  <circle cx="720" cy="200" r="2" fill="#e6edf3" opacity="0.6"/>
+  <circle cx="720" cy="215" r="2" fill="#e6edf3" opacity="0.6"/>
+
+  <!-- Distance labels -->
+  <!-- f distance SLM to lens -->
+  <line x1="225" y1="290" x2="225" y2="295" stroke="#8b949e" stroke-width="0.5"/>
+  <line x1="400" y1="290" x2="400" y2="295" stroke="#8b949e" stroke-width="0.5"/>
+  <line x1="225" y1="293" x2="400" y2="293" stroke="#8b949e" stroke-width="0.5" marker-end="url(#arrowW)" marker-start="url(#arrowW)"/>
+  <text x="312" y="308" fill="#8b949e" font-size="9" text-anchor="middle">f</text>
+  <!-- f distance lens to focal plane -->
+  <line x1="400" y1="290" x2="400" y2="295" stroke="#8b949e" stroke-width="0.5"/>
+  <line x1="560" y1="290" x2="560" y2="295" stroke="#8b949e" stroke-width="0.5"/>
+  <line x1="400" y1="293" x2="560" y2="293" stroke="#8b949e" stroke-width="0.5"/>
+  <text x="480" y="308" fill="#8b949e" font-size="9" text-anchor="middle">f</text>
+
+  <!-- Fourier Transform relationship box -->
+  <rect x="100" y="340" width="600" height="140" rx="8" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+  <text x="400" y="365" fill="#58a6ff" font-size="12" font-weight="bold" text-anchor="middle">Fourier Transform Relationship</text>
+
+  <text x="120" y="390" fill="#e6edf3" font-size="11">SLM plane:</text>
+  <text x="230" y="390" fill="#f0883e" font-size="11">A(x,y) * exp(i * phi(x,y))</text>
+  <text x="520" y="390" fill="#8b949e" font-size="10">amplitude x phase modulation</text>
+
+  <!-- FT arrow -->
+  <line x1="310" y1="400" x2="310" y2="420" stroke="#58a6ff" stroke-width="1.5" marker-end="url(#arrowB)"/>
+  <text x="340" y="415" fill="#58a6ff" font-size="10" font-weight="bold">FT{ }</text>
+
+  <text x="120" y="440" fill="#e6edf3" font-size="11">Focal plane:</text>
+  <text x="230" y="440" fill="#3fb950" font-size="11">E(u,v) = FT{ A(x,y) * exp(i * phi(x,y)) }</text>
+
+  <text x="120" y="465" fill="#e6edf3" font-size="11">Trap intensity:</text>
+  <text x="230" y="465" fill="#3fb950" font-size="11">I(u,v) = |E(u,v)|^2</text>
+  <text x="520" y="465" fill="#8b949e" font-size="10">phase-only control of intensity pattern</text>
+</svg>

--- a/images/rollings/dinhot_trap_types.svg
+++ b/images/rollings/dinhot_trap_types.svg
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400" viewBox="0 0 800 400">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, sans-serif; }
+    </style>
+    <!-- Point trap Gaussian gradient -->
+    <radialGradient id="gaussGrad" cx="50%" cy="50%" r="35%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.95"/>
+      <stop offset="30%" stop-color="#3fb950" stop-opacity="0.7"/>
+      <stop offset="70%" stop-color="#3fb950" stop-opacity="0.2"/>
+      <stop offset="100%" stop-color="#3fb950" stop-opacity="0"/>
+    </radialGradient>
+    <!-- Donut gradient for vortex -->
+    <radialGradient id="donutOuter" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#a371f7" stop-opacity="0"/>
+      <stop offset="40%" stop-color="#a371f7" stop-opacity="0.05"/>
+      <stop offset="55%" stop-color="#a371f7" stop-opacity="0.8"/>
+      <stop offset="70%" stop-color="#ffffff" stop-opacity="0.9"/>
+      <stop offset="85%" stop-color="#a371f7" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#a371f7" stop-opacity="0"/>
+    </radialGradient>
+    <!-- Line trap gradient -->
+    <linearGradient id="lineGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f0883e" stop-opacity="0"/>
+      <stop offset="30%" stop-color="#f0883e" stop-opacity="0.3"/>
+      <stop offset="50%" stop-color="#ffffff" stop-opacity="0.9"/>
+      <stop offset="70%" stop-color="#f0883e" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#f0883e" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="400" fill="#0d1117"/>
+
+  <!-- Title -->
+  <text x="400" y="28" fill="#e6edf3" font-size="16" font-weight="bold" text-anchor="middle">Types of Optical Traps</text>
+
+  <!-- 1. Point Trap (Gaussian focus) -->
+  <g transform="translate(20, 50)">
+    <rect x="0" y="0" width="175" height="240" rx="6" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+    <text x="87" y="25" fill="#3fb950" font-size="12" font-weight="bold" text-anchor="middle">Point Trap</text>
+    <text x="87" y="40" fill="#8b949e" font-size="9" text-anchor="middle">(Gaussian focus)</text>
+
+    <!-- Intensity profile circle -->
+    <circle cx="87" cy="110" r="50" fill="url(#gaussGrad)"/>
+    <!-- Cross-section intensity curve below -->
+    <line x1="20" y1="190" x2="155" y2="190" stroke="#30363d" stroke-width="0.5"/>
+    <!-- Gaussian curve -->
+    <path d="M 20,190 C 30,190 45,188 55,185 C 65,178 75,155 87,148 C 99,155 109,178 119,185 C 129,188 144,190 155,190"
+          fill="none" stroke="#3fb950" stroke-width="1.5"/>
+    <text x="87" y="205" fill="#8b949e" font-size="8" text-anchor="middle">I(r) = I_0 * exp(-2r^2/w^2)</text>
+
+    <!-- Phase info -->
+    <text x="87" y="225" fill="#8b949e" font-size="8" text-anchor="middle">Phase: linear tilt</text>
+    <text x="87" y="236" fill="#8b949e" font-size="8" text-anchor="middle">phi = alpha*(u*x + v*y)</text>
+  </g>
+
+  <!-- 2. Line Trap (cylindrical lens phase) -->
+  <g transform="translate(210, 50)">
+    <rect x="0" y="0" width="175" height="240" rx="6" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+    <text x="87" y="25" fill="#f0883e" font-size="12" font-weight="bold" text-anchor="middle">Line Trap</text>
+    <text x="87" y="40" fill="#8b949e" font-size="9" text-anchor="middle">(cylindrical lens phase)</text>
+
+    <!-- Line intensity profile -->
+    <rect x="37" y="70" width="100" height="80" fill="none"/>
+    <rect x="77" y="70" width="20" height="80" fill="url(#lineGrad)"/>
+    <!-- Side glow -->
+    <rect x="67" y="70" width="10" height="80" fill="#f0883e" opacity="0.15"/>
+    <rect x="97" y="70" width="10" height="80" fill="#f0883e" opacity="0.15"/>
+
+    <!-- Cross-section -->
+    <line x1="20" y1="190" x2="155" y2="190" stroke="#30363d" stroke-width="0.5"/>
+    <!-- Sinc-like profile -->
+    <path d="M 20,190 L 50,189 C 60,188 70,183 77,170 C 82,158 85,148 87,148 C 89,148 92,158 97,170 C 104,183 114,188 124,189 L 155,190"
+          fill="none" stroke="#f0883e" stroke-width="1.5"/>
+    <text x="87" y="205" fill="#8b949e" font-size="8" text-anchor="middle">I(x) = I_0 / cosh^2(x/w)</text>
+
+    <text x="87" y="225" fill="#8b949e" font-size="8" text-anchor="middle">Phase: cylindrical</text>
+    <text x="87" y="236" fill="#8b949e" font-size="8" text-anchor="middle">phi = alpha*u*x + beta*v^2</text>
+  </g>
+
+  <!-- 3. Optical Vortex (donut shape) -->
+  <g transform="translate(400, 50)">
+    <rect x="0" y="0" width="175" height="240" rx="6" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+    <text x="87" y="25" fill="#a371f7" font-size="12" font-weight="bold" text-anchor="middle">Optical Vortex</text>
+    <text x="87" y="40" fill="#8b949e" font-size="9" text-anchor="middle">(helical phase, l=1)</text>
+
+    <!-- Donut intensity -->
+    <circle cx="87" cy="110" r="50" fill="url(#donutOuter)"/>
+    <!-- Dark center -->
+    <circle cx="87" cy="110" r="15" fill="#161b22"/>
+    <!-- Rotation arrow -->
+    <path d="M 107,90 A 25,25 0 1,1 100,83" fill="none" stroke="#a371f7" stroke-width="1" opacity="0.6"/>
+    <polygon points="100,83 103,88 96,87" fill="#a371f7" opacity="0.6"/>
+    <text x="87" y="115" fill="#a371f7" font-size="7" text-anchor="middle">OAM</text>
+
+    <!-- Cross-section -->
+    <line x1="20" y1="190" x2="155" y2="190" stroke="#30363d" stroke-width="0.5"/>
+    <!-- Donut cross-section (two peaks) -->
+    <path d="M 20,190 L 40,190 C 50,189 55,185 60,175 C 63,168 65,165 67,168 C 70,175 75,188 87,190 C 99,188 104,175 107,168 C 109,165 111,168 114,175 C 119,185 124,189 134,190 L 155,190"
+          fill="none" stroke="#a371f7" stroke-width="1.5"/>
+    <text x="87" y="205" fill="#8b949e" font-size="8" text-anchor="middle">I(r) ~ r^(2|l|) * exp(-2r^2/w^2)</text>
+
+    <text x="87" y="225" fill="#8b949e" font-size="8" text-anchor="middle">Phase: helical</text>
+    <text x="87" y="236" fill="#8b949e" font-size="8" text-anchor="middle">phi = l*theta (l=1,2,...)</text>
+  </g>
+
+  <!-- 4. Multi-plane Trap -->
+  <g transform="translate(590, 50)">
+    <rect x="0" y="0" width="185" height="240" rx="6" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+    <text x="92" y="25" fill="#58a6ff" font-size="12" font-weight="bold" text-anchor="middle">Multi-Plane Trap</text>
+    <text x="92" y="40" fill="#8b949e" font-size="9" text-anchor="middle">(3 traps at different z)</text>
+
+    <!-- 3D perspective view -->
+    <!-- Back plane (z=+1) -->
+    <rect x="55" y="60" width="70" height="35" rx="2" fill="none" stroke="#58a6ff" stroke-width="0.5" opacity="0.4"/>
+    <circle cx="90" cy="78" r="6" fill="#58a6ff" opacity="0.3"/>
+    <circle cx="90" cy="78" r="2" fill="#ffffff" opacity="0.5"/>
+    <text x="130" y="82" fill="#8b949e" font-size="7">z = +1</text>
+
+    <!-- Middle plane (z=0) -->
+    <rect x="40" y="90" width="85" height="45" rx="2" fill="none" stroke="#58a6ff" stroke-width="0.8" opacity="0.6"/>
+    <circle cx="82" cy="112" r="8" fill="#58a6ff" opacity="0.5"/>
+    <circle cx="82" cy="112" r="3" fill="#ffffff" opacity="0.7"/>
+    <text x="130" y="116" fill="#8b949e" font-size="7">z = 0</text>
+
+    <!-- Front plane (z=-1) -->
+    <rect x="25" y="125" width="100" height="55" rx="2" fill="none" stroke="#58a6ff" stroke-width="1" opacity="0.8"/>
+    <circle cx="75" cy="152" r="10" fill="#58a6ff" opacity="0.6"/>
+    <circle cx="75" cy="152" r="4" fill="#ffffff" opacity="0.9"/>
+    <text x="130" y="156" fill="#8b949e" font-size="7">z = -1</text>
+
+    <!-- z-axis arrow -->
+    <line x1="145" y1="170" x2="145" y2="65" stroke="#58a6ff" stroke-width="1" opacity="0.5"/>
+    <polygon points="145,65 142,72 148,72" fill="#58a6ff" opacity="0.5"/>
+    <text x="155" y="70" fill="#58a6ff" font-size="7">z</text>
+
+    <text x="92" y="205" fill="#8b949e" font-size="8" text-anchor="middle">Defocus encodes z:</text>
+    <text x="92" y="218" fill="#8b949e" font-size="8" text-anchor="middle">phi_z = beta*(u^2+v^2)*z_j</text>
+    <text x="92" y="236" fill="#8b949e" font-size="8" text-anchor="middle">2D hologram encodes 3D</text>
+  </g>
+
+  <!-- Bottom summary -->
+  <g transform="translate(20, 310)">
+    <rect x="0" y="0" width="760" height="75" rx="6" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+    <text x="20" y="22" fill="#e6edf3" font-size="10" font-weight="bold">All trap types are generated by the same SLM + GS algorithm framework:</text>
+    <text x="20" y="40" fill="#8b949e" font-size="9">The total phase at each SLM pixel is: phi(u,v) = arg( SUM_j w_j * exp(i * [K_linear_j + K_quadratic_j + K_vortex_j]) )</text>
+    <text x="20" y="55" fill="#8b949e" font-size="9">where K_linear steers laterally, K_quadratic shifts axially, and K_vortex = l*theta adds orbital angular momentum.</text>
+    <text x="20" y="68" fill="#8b949e" font-size="9">The GS algorithm optimizes phi(u,v) to equalize intensities across all traps simultaneously.</text>
+  </g>
+</svg>

--- a/images/rollings/dual_helmholtz.svg
+++ b/images/rollings/dual_helmholtz.svg
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" font-family="Segoe UI, Arial, sans-serif">
+  <defs>
+    <marker id="fwd" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#7aa2f7"/>
+    </marker>
+    <marker id="dual" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#bb9af7"/>
+    </marker>
+    <marker id="fwdRev" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#f7768e"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="400" fill="#0d1117" rx="10"/>
+
+  <!-- Title -->
+  <text x="400" y="35" text-anchor="middle" font-size="20" font-weight="bold" fill="#c0caf5">
+    Helmholtz Reciprocity — Forward vs Dual Light Transport
+  </text>
+
+  <!-- Dividing line -->
+  <line x1="400" y1="55" x2="400" y2="340" stroke="#30363d" stroke-width="1" stroke-dasharray="6,4"/>
+
+  <!-- LEFT: Forward path -->
+  <text x="200" y="70" text-anchor="middle" font-size="16" font-weight="bold" fill="#7aa2f7">Forward Path</text>
+
+  <!-- Projector (left side) -->
+  <rect x="40" y="130" width="80" height="60" rx="6" fill="#1a1b26" stroke="#7aa2f7" stroke-width="2"/>
+  <text x="80" y="155" text-anchor="middle" font-size="11" font-weight="bold" fill="#7aa2f7">Projector</text>
+  <text x="80" y="170" text-anchor="middle" font-size="9" fill="#565f89">Source</text>
+  <!-- Lens icon -->
+  <circle cx="120" cy="160" r="8" fill="none" stroke="#7aa2f7" stroke-width="1.5"/>
+
+  <!-- Scene (center-left) -->
+  <rect x="175" y="120" width="50" height="80" rx="4" fill="#24283b" stroke="#51cf66" stroke-width="2"/>
+  <text x="200" y="165" text-anchor="middle" font-size="10" fill="#51cf66">Scene</text>
+
+  <!-- Camera (right of left section) -->
+  <rect x="280" y="130" width="80" height="60" rx="6" fill="#1a1b26" stroke="#f7768e" stroke-width="2"/>
+  <text x="320" y="155" text-anchor="middle" font-size="11" font-weight="bold" fill="#f7768e">Camera</text>
+  <text x="320" y="170" text-anchor="middle" font-size="9" fill="#565f89">Detector</text>
+  <!-- Lens icon -->
+  <circle cx="280" cy="160" r="8" fill="none" stroke="#f7768e" stroke-width="1.5"/>
+
+  <!-- Forward arrows -->
+  <line x1="128" y1="155" x2="172" y2="155" stroke="#7aa2f7" stroke-width="2" marker-end="url(#fwd)"/>
+  <line x1="228" y1="155" x2="270" y2="155" stroke="#7aa2f7" stroke-width="2" marker-end="url(#fwd)"/>
+
+  <!-- Forward label -->
+  <text x="200" y="105" text-anchor="middle" font-size="11" fill="#a9b1d6">c = T * p</text>
+
+  <!-- Light rays (forward) -->
+  <line x1="130" y1="140" x2="173" y2="135" stroke="#7aa2f7" stroke-width="1" opacity="0.4"/>
+  <line x1="130" y1="175" x2="173" y2="180" stroke="#7aa2f7" stroke-width="1" opacity="0.4"/>
+  <line x1="228" y1="135" x2="272" y2="140" stroke="#7aa2f7" stroke-width="1" opacity="0.4"/>
+  <line x1="228" y1="180" x2="272" y2="175" stroke="#7aa2f7" stroke-width="1" opacity="0.4"/>
+
+  <!-- RIGHT: Dual path -->
+  <text x="600" y="70" text-anchor="middle" font-size="16" font-weight="bold" fill="#bb9af7">Dual Path</text>
+
+  <!-- Virtual Camera as source -->
+  <rect x="440" y="130" width="80" height="60" rx="6" fill="#1a1b26" stroke="#bb9af7" stroke-width="2"/>
+  <text x="480" y="148" text-anchor="middle" font-size="10" font-weight="bold" fill="#bb9af7">(Virtual)</text>
+  <text x="480" y="162" text-anchor="middle" font-size="10" font-weight="bold" fill="#bb9af7">Camera</text>
+  <text x="480" y="176" text-anchor="middle" font-size="9" fill="#565f89">Source</text>
+
+  <!-- Scene (center-right) -->
+  <rect x="575" y="120" width="50" height="80" rx="4" fill="#24283b" stroke="#51cf66" stroke-width="2"/>
+  <text x="600" y="165" text-anchor="middle" font-size="10" fill="#51cf66">Scene</text>
+
+  <!-- Virtual Projector as detector -->
+  <rect x="680" y="130" width="80" height="60" rx="6" fill="#1a1b26" stroke="#f7768e" stroke-width="2"/>
+  <text x="720" y="148" text-anchor="middle" font-size="10" font-weight="bold" fill="#f7768e">(Virtual)</text>
+  <text x="720" y="162" text-anchor="middle" font-size="10" font-weight="bold" fill="#f7768e">Projector</text>
+  <text x="720" y="176" text-anchor="middle" font-size="9" fill="#565f89">Detector</text>
+
+  <!-- Dual arrows (reversed direction) -->
+  <line x1="522" y1="155" x2="572" y2="155" stroke="#bb9af7" stroke-width="2" marker-end="url(#dual)"/>
+  <line x1="628" y1="155" x2="678" y2="155" stroke="#bb9af7" stroke-width="2" marker-end="url(#dual)"/>
+
+  <!-- Dual label -->
+  <text x="600" y="105" text-anchor="middle" font-size="11" fill="#a9b1d6">p_dual = T^T * c_dual</text>
+
+  <!-- Light rays (dual) -->
+  <line x1="524" y1="140" x2="573" y2="135" stroke="#bb9af7" stroke-width="1" opacity="0.4"/>
+  <line x1="524" y1="175" x2="573" y2="180" stroke="#bb9af7" stroke-width="1" opacity="0.4"/>
+  <line x1="628" y1="135" x2="676" y2="140" stroke="#bb9af7" stroke-width="1" opacity="0.4"/>
+  <line x1="628" y1="180" x2="676" y2="175" stroke="#bb9af7" stroke-width="1" opacity="0.4"/>
+
+  <!-- Equivalence equation box -->
+  <rect x="200" y="240" width="400" height="55" rx="8" fill="#1a1b26" stroke="#e0af68" stroke-width="2"/>
+  <text x="400" y="263" text-anchor="middle" font-size="15" font-weight="bold" fill="#e0af68">
+    T_forward = T_backward^T
+  </text>
+  <text x="400" y="283" text-anchor="middle" font-size="11" fill="#a9b1d6">
+    Same light paths, reversed direction
+  </text>
+
+  <!-- Symmetry arrows connecting left and right -->
+  <path d="M 200,220 C 200,235 250,240 260,240" fill="none" stroke="#565f89" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <path d="M 600,220 C 600,235 550,240 540,240" fill="none" stroke="#565f89" stroke-width="1.5" stroke-dasharray="4,3"/>
+
+  <!-- Bottom note -->
+  <text x="400" y="330" text-anchor="middle" font-size="12" fill="#565f89">
+    Helmholtz reciprocity: L(A-&gt;B) = L(B-&gt;A) for time-invariant, non-absorbing media
+  </text>
+  <text x="400" y="350" text-anchor="middle" font-size="11" fill="#565f89">
+    Physical basis: time-reversal symmetry of Maxwell's equations
+  </text>
+
+  <!-- Legend -->
+  <g transform="translate(620,310)">
+    <rect x="0" y="0" width="160" height="75" rx="5" fill="#1a1b26" stroke="#30363d" stroke-width="1"/>
+    <line x1="10" y1="18" x2="30" y2="18" stroke="#7aa2f7" stroke-width="2"/>
+    <text x="36" y="22" font-size="9" fill="#a9b1d6">Forward transport</text>
+    <line x1="10" y1="38" x2="30" y2="38" stroke="#bb9af7" stroke-width="2"/>
+    <text x="36" y="42" font-size="9" fill="#a9b1d6">Dual transport</text>
+    <rect x="10" y="52" width="16" height="10" rx="2" fill="#24283b" stroke="#51cf66" stroke-width="1"/>
+    <text x="36" y="62" font-size="9" fill="#a9b1d6">Scene geometry</text>
+  </g>
+</svg>

--- a/images/rollings/haptic_force_model.svg
+++ b/images/rollings/haptic_force_model.svg
@@ -1,0 +1,114 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 500" width="700" height="500">
+  <defs>
+    <linearGradient id="bgG4" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0d1117"/>
+      <stop offset="100%" stop-color="#161b22"/>
+    </linearGradient>
+    <radialGradient id="probeGrad" cx="0.4" cy="0.35" r="0.6">
+      <stop offset="0%" stop-color="#ffd700"/>
+      <stop offset="100%" stop-color="#996600"/>
+    </radialGradient>
+    <filter id="g4">
+      <feGaussianBlur stdDeviation="2" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <marker id="fArr" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#f85149"/>
+    </marker>
+    <marker id="sArr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#3fb950"/>
+    </marker>
+  </defs>
+
+  <rect width="700" height="500" fill="url(#bgG4)"/>
+
+  <!-- Title -->
+  <text x="350" y="30" text-anchor="middle" fill="#e6edf3" font-family="Arial, sans-serif" font-size="18" font-weight="bold">Spring-Damper Force Model</text>
+  <text x="350" y="48" text-anchor="middle" fill="#8b949e" font-family="Arial, sans-serif" font-size="11">Kelvin-Voigt contact model for haptic feedback</text>
+
+  <!-- ===== Main Diagram ===== -->
+
+  <!-- Surface (triangle mesh) -->
+  <polygon points="50,320 200,280 350,310 300,350 150,360" fill="#21262d" stroke="#58a6ff" stroke-width="2"/>
+  <polygon points="50,320 200,280 150,360" fill="#58a6ff" fill-opacity="0.08" stroke="#58a6ff" stroke-width="1"/>
+  <polygon points="200,280 350,310 300,350" fill="#58a6ff" fill-opacity="0.12" stroke="#58a6ff" stroke-width="1"/>
+  <polygon points="200,280 300,350 150,360" fill="#58a6ff" fill-opacity="0.06" stroke="#58a6ff" stroke-width="1"/>
+  <text x="200" y="370" text-anchor="middle" fill="#58a6ff" font-family="Arial, sans-serif" font-size="11">Surface Mesh</text>
+
+  <!-- Anchor point on surface -->
+  <circle cx="220" cy="300" r="6" fill="#3fb950" filter="url(#g4)"/>
+  <text x="220" y="295" text-anchor="middle" fill="#3fb950" font-family="Arial, sans-serif" font-size="10" font-weight="bold" dy="-10">p_contact</text>
+  <text x="220" y="295" text-anchor="middle" fill="#8b949e" font-family="Arial, sans-serif" font-size="8" dy="18">(anchor)</text>
+
+  <!-- Probe (sphere) -->
+  <circle cx="220" cy="180" r="22" fill="url(#probeGrad)" stroke="#ffd700" stroke-width="1.5" filter="url(#g4)"/>
+  <text x="220" y="185" text-anchor="middle" fill="#000" font-family="Arial, sans-serif" font-size="10" font-weight="bold">P</text>
+  <text x="258" y="172" fill="#ffd700" font-family="Arial, sans-serif" font-size="10" font-weight="bold">p_probe</text>
+
+  <!-- Spring (zigzag line connecting probe to anchor) -->
+  <polyline points="220,202 210,215 230,225 210,235 230,245 210,255 230,265 210,275 230,285 220,294"
+            fill="none" stroke="#3fb950" stroke-width="2"/>
+  <text x="245" y="250" fill="#3fb950" font-family="Arial, sans-serif" font-size="11" font-weight="bold">k</text>
+  <text x="245" y="264" fill="#8b949e" font-family="Arial, sans-serif" font-size="9">(spring)</text>
+
+  <!-- Damper (dashpot symbol) -->
+  <rect x="170" y="220" width="20" height="40" fill="none" stroke="#d29922" stroke-width="1.5"/>
+  <line x1="180" y1="220" x2="180" y2="210" stroke="#d29922" stroke-width="1.5"/>
+  <line x1="180" y1="260" x2="180" y2="270" stroke="#d29922" stroke-width="1.5"/>
+  <line x1="175" y1="240" x2="185" y2="240" stroke="#d29922" stroke-width="2"/>
+  <line x1="180" y1="210" x2="180" y2="202" stroke="#d29922" stroke-width="1"/>
+  <line x1="180" y1="270" x2="180" y2="294" stroke="#d29922" stroke-width="1"/>
+  <text x="158" y="250" fill="#d29922" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="end">b</text>
+  <text x="158" y="264" fill="#8b949e" font-family="Arial, sans-serif" font-size="9" text-anchor="end">(damper)</text>
+
+  <!-- Force vector arrow -->
+  <line x1="220" y1="160" x2="220" y2="90" stroke="#f85149" stroke-width="3" marker-end="url(#fArr)" filter="url(#g4)"/>
+  <text x="240" y="120" fill="#f85149" font-family="Arial, sans-serif" font-size="13" font-weight="bold">F</text>
+
+  <!-- Displacement label -->
+  <line x1="265" y1="180" x2="265" y2="300" stroke="#bc8cff" stroke-width="1" stroke-dasharray="4,2"/>
+  <line x1="260" y1="180" x2="270" y2="180" stroke="#bc8cff" stroke-width="1"/>
+  <line x1="260" y1="300" x2="270" y2="300" stroke="#bc8cff" stroke-width="1"/>
+  <text x="280" y="240" fill="#bc8cff" font-family="Arial, sans-serif" font-size="11" font-weight="bold">x</text>
+  <text x="280" y="254" fill="#8b949e" font-family="Arial, sans-serif" font-size="8">(displacement)</text>
+
+  <!-- Velocity arrow -->
+  <line x1="195" y1="170" x2="160" y2="140" stroke="#39d2c0" stroke-width="2" marker-end="url(#sArr)"/>
+  <text x="152" y="138" fill="#39d2c0" font-family="Arial, sans-serif" font-size="10" font-weight="bold" text-anchor="end">v</text>
+
+  <!-- ===== Equations ===== -->
+  <rect x="380" y="70" width="290" height="180" rx="10" fill="#21262d" stroke="#d29922" stroke-width="1.5"/>
+  <text x="525" y="95" text-anchor="middle" fill="#d29922" font-family="Arial, sans-serif" font-size="14" font-weight="bold">Force Equations</text>
+
+  <text x="400" y="125" fill="#e6edf3" font-family="monospace" font-size="13" filter="url(#g4)">F = -k * x - b * v</text>
+  <text x="400" y="148" fill="#8b949e" font-family="Arial, sans-serif" font-size="10">where:</text>
+  <text x="410" y="166" fill="#3fb950" font-family="monospace" font-size="10">k = stiffness   (N/m)</text>
+  <text x="410" y="184" fill="#bc8cff" font-family="monospace" font-size="10">x = p_probe - p_contact</text>
+  <text x="410" y="202" fill="#d29922" font-family="monospace" font-size="10">b = damping     (Ns/m)</text>
+  <text x="410" y="220" fill="#39d2c0" font-family="monospace" font-size="10">v = probe velocity</text>
+  <text x="410" y="240" fill="#f85149" font-family="monospace" font-size="10">F = feedback force vector</text>
+
+  <!-- Force clamping -->
+  <rect x="380" y="265" width="290" height="80" rx="10" fill="#21262d" stroke="#f85149" stroke-width="1.5"/>
+  <text x="525" y="290" text-anchor="middle" fill="#f85149" font-family="Arial, sans-serif" font-size="13" font-weight="bold">Force Clamping</text>
+
+  <text x="400" y="315" fill="#e6edf3" font-family="monospace" font-size="11">if |F| > F_max:</text>
+  <text x="420" y="335" fill="#e6edf3" font-family="monospace" font-size="11">F = F_max * (F / |F|)</text>
+
+  <!-- PHANToM specs -->
+  <rect x="380" y="360" width="290" height="80" rx="10" fill="#21262d" stroke="#bc8cff" stroke-width="1.5"/>
+  <text x="525" y="385" text-anchor="middle" fill="#bc8cff" font-family="Arial, sans-serif" font-size="13" font-weight="bold">PHANToM Omni Specs</text>
+  <text x="400" y="405" fill="#8b949e" font-family="monospace" font-size="10">Max force:  3.3 N continuous</text>
+  <text x="400" y="422" fill="#8b949e" font-family="monospace" font-size="10">Workspace:  160 x 120 x 70 mm</text>
+  <text x="400" y="435" fill="#8b949e" font-family="monospace" font-size="10">Update:     1000 Hz (1 kHz)</text>
+
+  <!-- Legend -->
+  <rect x="30" y="395" width="320" height="90" rx="8" fill="#21262d" stroke="#30363d" stroke-width="1"/>
+  <text x="190" y="415" text-anchor="middle" fill="#e6edf3" font-family="Arial, sans-serif" font-size="11" font-weight="bold">Diagram Legend</text>
+  <circle cx="52" cy="432" r="5" fill="#ffd700"/>
+  <text x="65" y="436" fill="#8b949e" font-family="Arial, sans-serif" font-size="10">Probe cursor (user-controlled)</text>
+  <circle cx="52" cy="452" r="5" fill="#3fb950"/>
+  <text x="65" y="456" fill="#8b949e" font-family="Arial, sans-serif" font-size="10">Contact anchor on surface</text>
+  <line x1="42" y1="472" x2="62" y2="472" stroke="#f85149" stroke-width="2.5"/>
+  <text x="65" y="476" fill="#8b949e" font-family="Arial, sans-serif" font-size="10">Computed feedback force F</text>
+</svg>

--- a/images/rollings/haptic_octree.svg
+++ b/images/rollings/haptic_octree.svg
@@ -1,0 +1,189 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" width="800" height="600">
+  <defs>
+    <linearGradient id="bgG2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0d1117"/>
+      <stop offset="100%" stop-color="#161b22"/>
+    </linearGradient>
+    <filter id="glow2">
+      <feGaussianBlur stdDeviation="1.5" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="600" fill="url(#bgG2)"/>
+
+  <!-- Title -->
+  <text x="400" y="32" text-anchor="middle" fill="#e6edf3" font-family="Arial, sans-serif" font-size="18" font-weight="bold">Octree Spatial Partitioning</text>
+  <text x="400" y="52" text-anchor="middle" fill="#8b949e" font-family="Arial, sans-serif" font-size="11">Recursive 3D subdivision into 8 axis-aligned octants</text>
+
+  <!-- ===== Left: 3D Cube Visualization ===== -->
+  <text x="200" y="80" text-anchor="middle" fill="#d29922" font-family="Arial, sans-serif" font-size="13" font-weight="bold">3D Octree Subdivision</text>
+
+  <!-- Outer cube (depth 0) - isometric projection -->
+  <!-- Back face -->
+  <polygon points="80,140 280,110 360,170 160,200" fill="none" stroke="#30363d" stroke-width="1.5" opacity="0.5"/>
+  <!-- Left face -->
+  <polygon points="80,140 160,200 160,380 80,320" fill="none" stroke="#30363d" stroke-width="1.5" opacity="0.5"/>
+  <!-- Bottom face -->
+  <polygon points="160,380 360,350 360,170 160,200" fill="none" stroke="#30363d" stroke-width="1.5" opacity="0.5"/>
+  <!-- Top face -->
+  <polygon points="80,140 280,110 280,290 80,320" fill="none" stroke="#30363d" stroke-width="1.5" opacity="0.5"/>
+  <!-- Right face -->
+  <polygon points="280,110 360,170 360,350 280,290" fill="none" stroke="#30363d" stroke-width="1.5" opacity="0.5"/>
+  <!-- Front face -->
+  <polygon points="80,320 280,290 360,350 160,380" fill="none" stroke="#30363d" stroke-width="1.5" opacity="0.5"/>
+
+  <!-- Subdivision lines (depth 1) -->
+  <!-- Horizontal mid -->
+  <line x1="80" y1="230" x2="280" y2="200" stroke="#58a6ff" stroke-width="1" opacity="0.4"/>
+  <line x1="280" y1="200" x2="360" y2="260" stroke="#58a6ff" stroke-width="1" opacity="0.4"/>
+  <line x1="160" y1="290" x2="360" y2="260" stroke="#58a6ff" stroke-width="1" opacity="0.4"/>
+  <line x1="80" y1="230" x2="160" y2="290" stroke="#58a6ff" stroke-width="1" opacity="0.4"/>
+
+  <!-- Vertical mid (left-right) -->
+  <line x1="180" y1="125" x2="180" y2="305" stroke="#58a6ff" stroke-width="1" opacity="0.4"/>
+  <line x1="260" y1="265" x2="260" y2="165" stroke="#58a6ff" stroke-width="1" opacity="0.4"/>
+
+  <!-- Front-back mid -->
+  <line x1="120" y1="170" x2="120" y2="350" stroke="#58a6ff" stroke-width="1" opacity="0.4"/>
+  <line x1="320" y1="140" x2="320" y2="320" stroke="#58a6ff" stroke-width="1" opacity="0.4"/>
+
+  <!-- Octant labels (visible in front face) -->
+  <!-- Octant 0: left-bottom-front -->
+  <rect x="88" y="280" width="28" height="18" rx="3" fill="#f85149" opacity="0.25"/>
+  <text x="102" y="293" text-anchor="middle" fill="#f85149" font-family="monospace" font-size="11" font-weight="bold">0</text>
+
+  <!-- Octant 1: right-bottom-front -->
+  <rect x="156" y="280" width="28" height="18" rx="3" fill="#d29922" opacity="0.25"/>
+  <text x="170" y="293" text-anchor="middle" fill="#d29922" font-family="monospace" font-size="11" font-weight="bold">1</text>
+
+  <!-- Octant 2: left-top-front -->
+  <rect x="88" y="240" width="28" height="18" rx="3" fill="#3fb950" opacity="0.25"/>
+  <text x="102" y="253" text-anchor="middle" fill="#3fb950" font-family="monospace" font-size="11" font-weight="bold">2</text>
+
+  <!-- Octant 3: right-top-front -->
+  <rect x="156" y="240" width="28" height="18" rx="3" fill="#39d2c0" opacity="0.25"/>
+  <text x="170" y="253" text-anchor="middle" fill="#39d2c0" font-family="monospace" font-size="11" font-weight="bold">3</text>
+
+  <!-- Octant 6: left-top-back -->
+  <rect x="186" y="170" width="28" height="18" rx="3" fill="#bc8cff" opacity="0.25"/>
+  <text x="200" y="183" text-anchor="middle" fill="#bc8cff" font-family="monospace" font-size="11" font-weight="bold">6</text>
+
+  <!-- Octant 7: right-top-back -->
+  <rect x="264" y="170" width="28" height="18" rx="3" fill="#58a6ff" opacity="0.25"/>
+  <text x="278" y="183" text-anchor="middle" fill="#58a6ff" font-family="monospace" font-size="11" font-weight="bold">7</text>
+
+  <!-- Triangle mesh A (small triangle in octant 0) -->
+  <polygon points="92,308 108,290 115,310" fill="#f85149" fill-opacity="0.4" stroke="#f85149" stroke-width="1.5"/>
+  <polygon points="96,300 112,286 118,304" fill="none" stroke="#ff6b6b" stroke-width="0.8"/>
+
+  <!-- Triangle mesh B (small triangle in octant 3) -->
+  <polygon points="158,250 175,238 180,258" fill="#39d2c0" fill-opacity="0.4" stroke="#39d2c0" stroke-width="1.5"/>
+  <polygon points="162,246 178,234 182,252" fill="none" stroke="#5eecd0" stroke-width="0.8"/>
+
+  <text x="100" y="330" text-anchor="middle" fill="#f85149" font-family="Arial, sans-serif" font-size="9">Mesh A</text>
+  <text x="175" y="270" text-anchor="middle" fill="#39d2c0" font-family="Arial, sans-serif" font-size="9">Mesh B</text>
+
+  <!-- Depth label -->
+  <text x="70" y="395" fill="#8b949e" font-family="Arial, sans-serif" font-size="10">Depth 0 (root)</text>
+  <rect x="60" y="400" width="120" height="4" rx="2" fill="#30363d"/>
+  <text x="70" y="420" fill="#58a6ff" font-family="Arial, sans-serif" font-size="10">Depth 1 (8 octants)</text>
+  <rect x="60" y="425" width="120" height="4" rx="2" fill="#58a6ff" opacity="0.4"/>
+  <text x="70" y="445" fill="#bc8cff" font-family="Arial, sans-serif" font-size="10">Depth 2+ (recursive)</text>
+  <rect x="60" y="450" width="120" height="4" rx="2" fill="#bc8cff" opacity="0.3"/>
+
+  <!-- ===== Right: Index Formula and Table ===== -->
+  <text x="590" y="80" text-anchor="middle" fill="#d29922" font-family="Arial, sans-serif" font-size="13" font-weight="bold">Child Index Formula</text>
+
+  <!-- Formula box -->
+  <rect x="440" y="90" width="300" height="50" rx="8" fill="#21262d" stroke="#d29922" stroke-width="1.5"/>
+  <text x="590" y="115" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="14" filter="url(#glow2)">
+    idx = (x>=cx) + 2(y>=cy) + 4(z>=cz)
+  </text>
+  <text x="590" y="132" text-anchor="middle" fill="#8b949e" font-family="Arial, sans-serif" font-size="9">where (cx, cy, cz) is the node center</text>
+
+  <!-- Index table -->
+  <text x="590" y="165" text-anchor="middle" fill="#39d2c0" font-family="Arial, sans-serif" font-size="12" font-weight="bold">Octant Index Table</text>
+
+  <!-- Table header -->
+  <rect x="440" y="175" width="300" height="25" rx="0" fill="#21262d"/>
+  <text x="470" y="192" text-anchor="middle" fill="#8b949e" font-family="monospace" font-size="10" font-weight="bold">Idx</text>
+  <text x="520" y="192" text-anchor="middle" fill="#8b949e" font-family="monospace" font-size="10" font-weight="bold">X</text>
+  <text x="580" y="192" text-anchor="middle" fill="#8b949e" font-family="monospace" font-size="10" font-weight="bold">Y</text>
+  <text x="640" y="192" text-anchor="middle" fill="#8b949e" font-family="monospace" font-size="10" font-weight="bold">Z</text>
+  <text x="710" y="192" text-anchor="middle" fill="#8b949e" font-family="monospace" font-size="10" font-weight="bold">Region</text>
+  <line x1="440" y1="200" x2="740" y2="200" stroke="#30363d" stroke-width="1"/>
+
+  <!-- Table rows -->
+  <text x="470" y="218" text-anchor="middle" fill="#f85149" font-family="monospace" font-size="10">0</text>
+  <text x="520" y="218" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">left</text>
+  <text x="580" y="218" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">bot</text>
+  <text x="640" y="218" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">front</text>
+  <text x="710" y="218" text-anchor="middle" fill="#f85149" font-family="monospace" font-size="9">000</text>
+
+  <text x="470" y="238" text-anchor="middle" fill="#d29922" font-family="monospace" font-size="10">1</text>
+  <text x="520" y="238" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">right</text>
+  <text x="580" y="238" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">bot</text>
+  <text x="640" y="238" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">front</text>
+  <text x="710" y="238" text-anchor="middle" fill="#d29922" font-family="monospace" font-size="9">001</text>
+
+  <text x="470" y="258" text-anchor="middle" fill="#3fb950" font-family="monospace" font-size="10">2</text>
+  <text x="520" y="258" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">left</text>
+  <text x="580" y="258" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">top</text>
+  <text x="640" y="258" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">front</text>
+  <text x="710" y="258" text-anchor="middle" fill="#3fb950" font-family="monospace" font-size="9">010</text>
+
+  <text x="470" y="278" text-anchor="middle" fill="#39d2c0" font-family="monospace" font-size="10">3</text>
+  <text x="520" y="278" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">right</text>
+  <text x="580" y="278" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">top</text>
+  <text x="640" y="278" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">front</text>
+  <text x="710" y="278" text-anchor="middle" fill="#39d2c0" font-family="monospace" font-size="9">011</text>
+
+  <text x="470" y="298" text-anchor="middle" fill="#d29922" font-family="monospace" font-size="10">4</text>
+  <text x="520" y="298" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">left</text>
+  <text x="580" y="298" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">bot</text>
+  <text x="640" y="298" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">back</text>
+  <text x="710" y="298" text-anchor="middle" fill="#d29922" font-family="monospace" font-size="9">100</text>
+
+  <text x="470" y="318" text-anchor="middle" fill="#58a6ff" font-family="monospace" font-size="10">5</text>
+  <text x="520" y="318" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">right</text>
+  <text x="580" y="318" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">bot</text>
+  <text x="640" y="318" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">back</text>
+  <text x="710" y="318" text-anchor="middle" fill="#58a6ff" font-family="monospace" font-size="9">101</text>
+
+  <text x="470" y="338" text-anchor="middle" fill="#bc8cff" font-family="monospace" font-size="10">6</text>
+  <text x="520" y="338" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">left</text>
+  <text x="580" y="338" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">top</text>
+  <text x="640" y="338" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">back</text>
+  <text x="710" y="338" text-anchor="middle" fill="#bc8cff" font-family="monospace" font-size="9">110</text>
+
+  <text x="470" y="358" text-anchor="middle" fill="#58a6ff" font-family="monospace" font-size="10">7</text>
+  <text x="520" y="358" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">right</text>
+  <text x="580" y="358" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">top</text>
+  <text x="640" y="358" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">back</text>
+  <text x="710" y="358" text-anchor="middle" fill="#58a6ff" font-family="monospace" font-size="9">111</text>
+
+  <!-- Stopping criteria -->
+  <text x="590" y="395" text-anchor="middle" fill="#d29922" font-family="Arial, sans-serif" font-size="12" font-weight="bold">Subdivision Stopping Criteria</text>
+
+  <rect x="440" y="405" width="300" height="100" rx="8" fill="#21262d" stroke="#30363d" stroke-width="1"/>
+  <text x="460" y="428" fill="#3fb950" font-family="monospace" font-size="11">max_depth = 8</text>
+  <text x="625" y="428" fill="#8b949e" font-family="Arial, sans-serif" font-size="9">Maximum tree depth</text>
+  <text x="460" y="450" fill="#3fb950" font-family="monospace" font-size="11">min_triangles = 4</text>
+  <text x="640" y="450" fill="#8b949e" font-family="Arial, sans-serif" font-size="9">factorU from C++</text>
+  <text x="460" y="472" fill="#3fb950" font-family="monospace" font-size="11">min_occupancy = 2%</text>
+  <text x="640" y="472" fill="#8b949e" font-family="Arial, sans-serif" font-size="9">factorG from C++</text>
+  <text x="460" y="494" fill="#8b949e" font-family="monospace" font-size="10">// Stop if depth >= max OR</text>
+  <text x="460" y="498" fill="#8b949e" font-family="monospace" font-size="10">// tris &lt;= min OR ratio &lt; 2%</text>
+
+  <!-- Complexity note -->
+  <rect x="60" y="470" width="340" height="70" rx="8" fill="#21262d" stroke="#58a6ff" stroke-width="1"/>
+  <text x="230" y="492" text-anchor="middle" fill="#58a6ff" font-family="Arial, sans-serif" font-size="12" font-weight="bold">Complexity Analysis</text>
+  <text x="230" y="510" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">Build:  O(N log N)   average case</text>
+  <text x="230" y="526" text-anchor="middle" fill="#e6edf3" font-family="monospace" font-size="10">Query:  O(N log N)   vs O(N^2) brute force</text>
+
+  <!-- Bottom note -->
+  <text x="400" y="570" text-anchor="middle" fill="#8b949e" font-family="Arial, sans-serif" font-size="10">Based on original Octrees.cpp from UDEC Haptic SIM (2008)</text>
+  <text x="400" y="586" text-anchor="middle" fill="#8b949e" font-family="Arial, sans-serif" font-size="9">Reference: Ericson (2004), Real-Time Collision Detection, Ch. 7</text>
+</svg>

--- a/images/rollings/owp_information_theory.svg
+++ b/images/rollings/owp_information_theory.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="500" viewBox="0 0 800 500">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, sans-serif; fill: #e6edf3; }
+      .title { font-size: 16px; font-weight: bold; fill: #58a6ff; }
+      .heading { font-size: 13px; font-weight: bold; }
+      .label { font-size: 12px; fill: #e6edf3; }
+      .math { font-size: 12px; fill: #d2a8ff; font-style: italic; }
+      .sublabel { font-size: 10px; fill: #8b949e; }
+      .eq { font-size: 11px; fill: #e6edf3; }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="500" fill="#0d1117"/>
+
+  <!-- Title -->
+  <text class="title" x="400" y="32" text-anchor="middle">Information Theory: Entropy, Conditional Entropy, and Mutual Information</text>
+
+  <!-- Venn Diagram -->
+  <!-- H(X) circle -->
+  <circle cx="300" cy="230" r="140" fill="#58a6ff" fill-opacity="0.12" stroke="#58a6ff" stroke-width="2"/>
+  <!-- H(Y) circle -->
+  <circle cx="480" cy="230" r="140" fill="#7ee787" fill-opacity="0.12" stroke="#7ee787" stroke-width="2"/>
+
+  <!-- Overlap region (intersection) highlight -->
+  <clipPath id="clipX">
+    <circle cx="300" cy="230" r="140"/>
+  </clipPath>
+  <circle cx="480" cy="230" r="140" fill="#f0883e" fill-opacity="0.2" clip-path="url(#clipX)"/>
+
+  <!-- Labels inside diagram -->
+  <!-- H(X|Y) - left only -->
+  <text class="heading" x="228" y="222" text-anchor="middle" fill="#58a6ff">H(X|Y)</text>
+  <text class="sublabel" x="228" y="240" text-anchor="middle">Uncertainty in X</text>
+  <text class="sublabel" x="228" y="254" text-anchor="middle">not explained by Y</text>
+
+  <!-- I(X;Y) - overlap -->
+  <text class="heading" x="390" y="215" text-anchor="middle" fill="#f0883e">I(X;Y)</text>
+  <text class="sublabel" x="390" y="233" text-anchor="middle">Mutual</text>
+  <text class="sublabel" x="390" y="247" text-anchor="middle">Information</text>
+
+  <!-- H(Y|X) - right only -->
+  <text class="heading" x="552" y="222" text-anchor="middle" fill="#7ee787">H(Y|X)</text>
+  <text class="sublabel" x="552" y="240" text-anchor="middle">Uncertainty in Y</text>
+  <text class="sublabel" x="552" y="254" text-anchor="middle">not explained by X</text>
+
+  <!-- Outer labels -->
+  <text class="math" x="210" y="110" text-anchor="middle">H(X)</text>
+  <line x1="210" y1="115" x2="260" y2="145" stroke="#58a6ff" stroke-width="0.8" stroke-dasharray="3,2"/>
+
+  <text class="math" x="570" y="110" text-anchor="middle">H(Y)</text>
+  <line x1="570" y1="115" x2="520" y2="145" stroke="#7ee787" stroke-width="0.8" stroke-dasharray="3,2"/>
+
+  <!-- H(X,Y) brace at bottom -->
+  <line x1="170" y1="385" x2="610" y2="385" stroke="#8b949e" stroke-width="1"/>
+  <line x1="170" y1="380" x2="170" y2="390" stroke="#8b949e" stroke-width="1"/>
+  <line x1="610" y1="380" x2="610" y2="390" stroke="#8b949e" stroke-width="1"/>
+  <text class="math" x="390" y="405" text-anchor="middle">H(X, Y)</text>
+
+  <!-- Equations box -->
+  <rect x="30" y="420" width="740" height="70" fill="#161b22" stroke="#30363d" stroke-width="1" rx="6"/>
+
+  <text class="eq" x="50" y="445">Key Relations:</text>
+  <text class="eq" x="50" y="465" fill="#d2a8ff">I(X;Y) = H(X) - H(X|Y) = H(Y) - H(Y|X)</text>
+  <text class="eq" x="430" y="445" fill="#d2a8ff">H(X,Y) = H(X) + H(Y|X) = H(Y) + H(X|Y)</text>
+  <text class="eq" x="430" y="465" fill="#d2a8ff">H(X,Y) = H(X) + H(Y) - I(X;Y)</text>
+
+  <!-- OWP context note -->
+  <text class="sublabel" x="50" y="485">OWP: X = sampled wells (X_f), Y = unsampled field (X^f). Maximize I(X_f; X^f) = minimize posterior uncertainty H(X^f | X_f).</text>
+</svg>

--- a/images/rollings/owp_resolvability.svg
+++ b/images/rollings/owp_resolvability.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="400" viewBox="0 0 700 400">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, sans-serif; fill: #e6edf3; }
+      .title { font-size: 15px; font-weight: bold; fill: #58a6ff; }
+      .label { font-size: 11px; fill: #e6edf3; }
+      .sublabel { font-size: 9.5px; fill: #8b949e; }
+      .math { font-size: 11px; fill: #d2a8ff; font-style: italic; }
+      .axis-label { font-size: 12px; fill: #e6edf3; }
+      .tick { font-size: 9px; fill: #8b949e; }
+      .gridline { stroke: #21262d; stroke-width: 0.5; }
+    </style>
+    <linearGradient id="areaGrad" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#7ee787" stop-opacity="0.25"/>
+      <stop offset="100%" stop-color="#7ee787" stop-opacity="0.02"/>
+    </linearGradient>
+    <marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0,0 8,3 0,6" fill="#e6edf3"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="700" height="400" fill="#0d1117"/>
+
+  <!-- Title -->
+  <text class="title" x="350" y="30" text-anchor="middle">Resolvability Capacity Curve C_k</text>
+
+  <!-- Plot area: x=80..620, y=55..330 -->
+  <!-- Grid lines -->
+  <line class="gridline" x1="80" y1="110" x2="620" y2="110"/>
+  <line class="gridline" x1="80" y1="165" x2="620" y2="165"/>
+  <line class="gridline" x1="80" y1="220" x2="620" y2="220"/>
+  <line class="gridline" x1="80" y1="275" x2="620" y2="275"/>
+
+  <!-- Axes -->
+  <line x1="80" y1="330" x2="635" y2="330" stroke="#e6edf3" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="80" y1="340" x2="80" y2="48" stroke="#e6edf3" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Y-axis ticks and labels -->
+  <text class="tick" x="72" y="334" text-anchor="end">0.0</text>
+  <text class="tick" x="72" y="279" text-anchor="end">0.2</text>
+  <text class="tick" x="72" y="224" text-anchor="end">0.4</text>
+  <text class="tick" x="72" y="169" text-anchor="end">0.6</text>
+  <text class="tick" x="72" y="114" text-anchor="end">0.8</text>
+  <text class="tick" x="72" y="59" text-anchor="end">1.0</text>
+
+  <!-- X-axis ticks -->
+  <text class="tick" x="80" y="348" text-anchor="middle">0</text>
+  <text class="tick" x="188" y="348" text-anchor="middle">5</text>
+  <text class="tick" x="296" y="348" text-anchor="middle">10</text>
+  <text class="tick" x="404" y="348" text-anchor="middle">15</text>
+  <text class="tick" x="512" y="348" text-anchor="middle">20</text>
+  <text class="tick" x="620" y="348" text-anchor="middle">25</text>
+
+  <!-- Axis labels -->
+  <text class="axis-label" x="350" y="375" text-anchor="middle">Number of samples k</text>
+  <text class="axis-label" x="28" y="195" text-anchor="middle" transform="rotate(-90,28,195)">C_k = I(f*_k) / H(X)</text>
+
+  <!-- 1.0 dashed line -->
+  <line x1="80" y1="55" x2="620" y2="55" stroke="#8b949e" stroke-width="0.8" stroke-dasharray="4,3"/>
+
+  <!-- Shaded "sufficient samples" region -->
+  <!-- Area under curve up to stopping point (k~12, x~340) -->
+  <path d="M80,330 L80,330 L102,308 L124,282 L146,255 L168,228 L190,202 L212,180 L234,162 L256,148 L278,137 L300,128 L322,121 L340,117 L340,330 Z" fill="url(#areaGrad)"/>
+
+  <!-- Curve: C_k = 1 - exp(-0.18*k) approximately -->
+  <path d="M80,330 C100,290 120,265 146,230 C170,200 190,178 212,160 C234,145 256,133 278,124 C300,117 322,112 340,108 C360,105 380,102 404,99 C430,96 460,93 490,90 C520,88 550,86 580,84 C600,83 620,82 620,82" fill="none" stroke="#7ee787" stroke-width="2.5"/>
+
+  <!-- Stopping rule point -->
+  <circle cx="340" cy="108" r="5" fill="#f97583" stroke="#f97583" stroke-width="1"/>
+  <line x1="340" y1="108" x2="340" y2="330" stroke="#f97583" stroke-width="1" stroke-dasharray="5,4"/>
+
+  <!-- Stopping rule annotation -->
+  <line x1="345" y1="105" x2="420" y2="78" stroke="#f97583" stroke-width="0.8"/>
+  <text class="label" x="425" y="75" fill="#f97583">Stopping point</text>
+  <text class="math" x="425" y="90">dC_k/dk &lt; epsilon</text>
+
+  <!-- "Sufficient samples" label -->
+  <text class="sublabel" x="210" y="310" text-anchor="middle" fill="#7ee787">Sufficient</text>
+  <text class="sublabel" x="210" y="322" text-anchor="middle" fill="#7ee787">samples</text>
+
+  <!-- "Diminishing returns" label -->
+  <text class="sublabel" x="510" y="75" text-anchor="middle" fill="#8b949e">Diminishing returns</text>
+  <path d="M460,78 L445,85" fill="none" stroke="#8b949e" stroke-width="0.5"/>
+
+  <!-- Plateau annotation -->
+  <text class="sublabel" x="600" y="72" text-anchor="middle">C_k -> 1</text>
+</svg>

--- a/images/rollings/robot_dh_frames.svg
+++ b/images/rollings/robot_dh_frames.svg
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500" font-family="Arial, sans-serif">
+  <defs>
+    <marker id="ax" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#E53935"/>
+    </marker>
+    <marker id="ay" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#43A047"/>
+    </marker>
+    <marker id="az" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#1E88E5"/>
+    </marker>
+  </defs>
+
+  <text x="400" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#333">Scorbot III — Denavit-Hartenberg Frames (Side View)</text>
+
+  <!-- Ground -->
+  <rect x="50" y="400" width="700" height="10" fill="#8D6E63" rx="3"/>
+
+  <!-- Base (Frame 0) -->
+  <rect x="345" y="360" width="110" height="40" rx="5" fill="#607D8B" stroke="#37474F" stroke-width="2"/>
+  <text x="400" y="385" text-anchor="middle" font-size="11" fill="white" font-weight="bold">Base</text>
+
+  <!-- Frame 0 axes -->
+  <line x1="400" y1="360" x2="440" y2="360" stroke="#E53935" stroke-width="2" marker-end="url(#ax)"/>
+  <line x1="400" y1="360" x2="400" y2="320" stroke="#1E88E5" stroke-width="2" marker-end="url(#az)"/>
+  <text x="448" y="363" font-size="9" fill="#E53935">x₀</text>
+  <text x="404" y="316" font-size="9" fill="#1E88E5">z₀</text>
+  <text x="380" y="355" font-size="10" fill="#FF9800" font-weight="bold">Frame 0</text>
+
+  <!-- Link 1: d1=340mm vertical -->
+  <line x1="400" y1="360" x2="408" y2="220" stroke="#78909C" stroke-width="8" stroke-linecap="round"/>
+  <text x="420" y="290" font-size="11" fill="#546E7A" font-style="italic">d₁ = 340</text>
+
+  <!-- Joint 1 (Frame 1) -->
+  <circle cx="408" cy="220" r="10" fill="#FFC107" stroke="#F57F17" stroke-width="2"/>
+  <text x="408" y="224" text-anchor="middle" font-size="9" fill="#333" font-weight="bold">θ₁</text>
+
+  <!-- Frame 1 axes -->
+  <line x1="408" y1="220" x2="448" y2="220" stroke="#E53935" stroke-width="2" marker-end="url(#ax)"/>
+  <line x1="408" y1="220" x2="408" y2="180" stroke="#1E88E5" stroke-width="2" marker-end="url(#az)"/>
+  <text x="456" y="223" font-size="9" fill="#E53935">x₁</text>
+  <text x="412" y="176" font-size="9" fill="#1E88E5">z₁</text>
+  <text x="365" y="210" font-size="10" fill="#FF9800" font-weight="bold">Frame 1</text>
+  <text x="418" y="235" font-size="9" fill="#757575">a₁=16</text>
+
+  <!-- Link 2: a2=220mm -->
+  <line x1="408" y1="220" x2="540" y2="160" stroke="#78909C" stroke-width="8" stroke-linecap="round"/>
+  <text x="470" y="175" font-size="11" fill="#546E7A" font-style="italic">a₂ = 220</text>
+
+  <!-- Joint 2 (Frame 2) -->
+  <circle cx="540" cy="160" r="10" fill="#FFC107" stroke="#F57F17" stroke-width="2"/>
+  <text x="540" y="164" text-anchor="middle" font-size="9" fill="#333" font-weight="bold">θ₂</text>
+  <text x="555" y="155" font-size="10" fill="#FF9800" font-weight="bold">Frame 2</text>
+
+  <!-- Link 3: a3=220mm -->
+  <line x1="540" y1="160" x2="660" y2="220" stroke="#78909C" stroke-width="8" stroke-linecap="round"/>
+  <text x="605" y="180" font-size="11" fill="#546E7A" font-style="italic">a₃ = 220</text>
+
+  <!-- Joint 3 (Frame 3) -->
+  <circle cx="660" cy="220" r="10" fill="#FFC107" stroke="#F57F17" stroke-width="2"/>
+  <text x="660" y="224" text-anchor="middle" font-size="9" fill="#333" font-weight="bold">θ₃</text>
+  <text x="675" y="215" font-size="10" fill="#FF9800" font-weight="bold">Frame 3</text>
+
+  <!-- Link 4: wrist -->
+  <line x1="660" y1="220" x2="700" y2="250" stroke="#78909C" stroke-width="5" stroke-linecap="round"/>
+
+  <!-- Joint 4 (Frame 4) -->
+  <circle cx="700" cy="250" r="8" fill="#FFC107" stroke="#F57F17" stroke-width="2"/>
+  <text x="700" y="253" text-anchor="middle" font-size="8" fill="#333" font-weight="bold">θ₄</text>
+  <text x="715" y="248" font-size="9" fill="#FF9800" font-weight="bold">Frame 4</text>
+
+  <!-- Link 5: d5=151mm to gripper -->
+  <line x1="700" y1="250" x2="700" y2="310" stroke="#78909C" stroke-width="4" stroke-linecap="round"/>
+  <text x="715" y="280" font-size="10" fill="#546E7A" font-style="italic">d₅ = 151</text>
+
+  <!-- Joint 5 / End Effector (Frame 5) -->
+  <circle cx="700" cy="310" r="8" fill="#FFC107" stroke="#F57F17" stroke-width="2"/>
+  <text x="700" y="313" text-anchor="middle" font-size="8" fill="#333" font-weight="bold">θ₅</text>
+
+  <!-- Gripper -->
+  <line x1="693" y1="318" x2="688" y2="345" stroke="#F44336" stroke-width="3" stroke-linecap="round"/>
+  <line x1="707" y1="318" x2="712" y2="345" stroke="#F44336" stroke-width="3" stroke-linecap="round"/>
+  <text x="700" y="360" text-anchor="middle" font-size="10" fill="#F44336" font-weight="bold">Gripper</text>
+  <text x="700" y="375" text-anchor="middle" font-size="9" fill="#F44336">Frame 5 (EE)</text>
+
+  <!-- DH Table -->
+  <g transform="translate(60,80)">
+    <rect x="0" y="0" width="280" height="170" rx="5" fill="white" stroke="#ccc" stroke-width="1"/>
+    <text x="140" y="20" text-anchor="middle" font-size="12" font-weight="bold" fill="#333">DH Parameters</text>
+    <line x1="0" y1="28" x2="280" y2="28" stroke="#ccc"/>
+
+    <!-- Header -->
+    <text x="25" y="45" text-anchor="middle" font-size="10" font-weight="bold" fill="#555">Joint</text>
+    <text x="80" y="45" text-anchor="middle" font-size="10" font-weight="bold" fill="#555">α (rad)</text>
+    <text x="135" y="45" text-anchor="middle" font-size="10" font-weight="bold" fill="#555">d (mm)</text>
+    <text x="190" y="45" text-anchor="middle" font-size="10" font-weight="bold" fill="#555">a (mm)</text>
+    <text x="245" y="45" text-anchor="middle" font-size="10" font-weight="bold" fill="#555">θ</text>
+    <line x1="0" y1="52" x2="280" y2="52" stroke="#eee"/>
+
+    <!-- Data rows -->
+    <text x="25" y="70" text-anchor="middle" font-size="10" fill="#333">1</text>
+    <text x="80" y="70" text-anchor="middle" font-size="10" fill="#333">-π/2</text>
+    <text x="135" y="70" text-anchor="middle" font-size="10" fill="#333">340</text>
+    <text x="190" y="70" text-anchor="middle" font-size="10" fill="#333">16</text>
+    <text x="245" y="70" text-anchor="middle" font-size="10" fill="#FFC107">θ₁</text>
+
+    <text x="25" y="90" text-anchor="middle" font-size="10" fill="#333">2</text>
+    <text x="80" y="90" text-anchor="middle" font-size="10" fill="#333">0</text>
+    <text x="135" y="90" text-anchor="middle" font-size="10" fill="#333">0</text>
+    <text x="190" y="90" text-anchor="middle" font-size="10" fill="#333">220</text>
+    <text x="245" y="90" text-anchor="middle" font-size="10" fill="#FFC107">θ₂</text>
+
+    <text x="25" y="110" text-anchor="middle" font-size="10" fill="#333">3</text>
+    <text x="80" y="110" text-anchor="middle" font-size="10" fill="#333">0</text>
+    <text x="135" y="110" text-anchor="middle" font-size="10" fill="#333">0</text>
+    <text x="190" y="110" text-anchor="middle" font-size="10" fill="#333">220</text>
+    <text x="245" y="110" text-anchor="middle" font-size="10" fill="#FFC107">θ₃</text>
+
+    <text x="25" y="130" text-anchor="middle" font-size="10" fill="#333">4</text>
+    <text x="80" y="130" text-anchor="middle" font-size="10" fill="#333">-π/2</text>
+    <text x="135" y="130" text-anchor="middle" font-size="10" fill="#333">0</text>
+    <text x="190" y="130" text-anchor="middle" font-size="10" fill="#333">0</text>
+    <text x="245" y="130" text-anchor="middle" font-size="10" fill="#FFC107">θ₄</text>
+
+    <text x="25" y="150" text-anchor="middle" font-size="10" fill="#333">5</text>
+    <text x="80" y="150" text-anchor="middle" font-size="10" fill="#333">0</text>
+    <text x="135" y="150" text-anchor="middle" font-size="10" fill="#333">151</text>
+    <text x="190" y="150" text-anchor="middle" font-size="10" fill="#333">0</text>
+    <text x="245" y="150" text-anchor="middle" font-size="10" fill="#FFC107">θ₅</text>
+  </g>
+
+  <!-- Units note -->
+  <text x="400" y="480" text-anchor="middle" font-size="10" fill="#999">All dimensions in millimeters. Joint angles θ₁–θ₅ are the variable parameters.</text>
+</svg>

--- a/images/rollings/robot_workspace.svg
+++ b/images/rollings/robot_workspace.svg
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 500" font-family="Segoe UI, Arial, sans-serif">
+  <defs>
+    <marker id="arrW" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#7aa2f7"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="700" height="500" fill="#0d1117" rx="10"/>
+
+  <!-- Title -->
+  <text x="350" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#c0caf5">
+    Scorbot III Workspace — Top-Down View
+  </text>
+
+  <!-- Reachable workspace boundary (outer) -->
+  <circle cx="350" cy="280" r="200" fill="none" stroke="#565f89" stroke-width="1.5" stroke-dasharray="8,4"/>
+  <text x="560" y="175" font-size="10" fill="#565f89">R_max = 591 mm</text>
+
+  <!-- Reachable workspace boundary (inner) -->
+  <circle cx="350" cy="280" r="25" fill="none" stroke="#565f89" stroke-width="1" stroke-dasharray="4,4"/>
+
+  <!-- Workspace fill (partial, showing 253 deg range) -->
+  <path d="M 350,280 L 195,105 A 200,200 0 1,1 195,455 Z" fill="#7aa2f7" opacity="0.06"/>
+  <text x="490" y="440" font-size="10" fill="#7aa2f7">Reachable workspace</text>
+  <text x="490" y="455" font-size="10" fill="#7aa2f7">(253 deg base range)</text>
+
+  <!-- Block circle arc (A-Z) -->
+  <circle cx="350" cy="280" r="150" fill="none" stroke="#51cf66" stroke-width="2" stroke-dasharray="0"/>
+  <!-- Only draw the upper arc portion with blocks -->
+  <path d="M 205,215 A 150,150 0 1,1 205,345" fill="none" stroke="#51cf66" stroke-width="2"/>
+
+  <!-- Letter blocks on arc -->
+  <g font-size="8" font-weight="bold" text-anchor="middle">
+    <!-- A (leftmost) -->
+    <rect x="194" y="200" width="16" height="16" rx="2" fill="#51cf66" stroke="#0d1117" stroke-width="0.5"/>
+    <text x="202" y="212" fill="#0d1117">A</text>
+    <!-- D -->
+    <rect x="210" y="162" width="16" height="16" rx="2" fill="#51cf66" stroke="#0d1117" stroke-width="0.5"/>
+    <text x="218" y="174" fill="#0d1117">D</text>
+    <!-- G -->
+    <rect x="240" y="135" width="16" height="16" rx="2" fill="#51cf66" stroke="#0d1117" stroke-width="0.5"/>
+    <text x="248" y="147" fill="#0d1117">G</text>
+    <!-- J -->
+    <rect x="280" y="118" width="16" height="16" rx="2" fill="#51cf66" stroke="#0d1117" stroke-width="0.5"/>
+    <text x="288" y="130" fill="#0d1117">J</text>
+    <!-- M -->
+    <rect x="330" y="112" width="16" height="16" rx="2" fill="#51cf66" stroke="#0d1117" stroke-width="0.5"/>
+    <text x="338" y="124" fill="#0d1117">M</text>
+    <!-- N (near top) -->
+    <rect x="360" y="112" width="16" height="16" rx="2" fill="#51cf66" stroke="#0d1117" stroke-width="0.5"/>
+    <text x="368" y="124" fill="#0d1117">N</text>
+    <!-- Q -->
+    <rect x="400" y="118" width="16" height="16" rx="2" fill="#51cf66" stroke="#0d1117" stroke-width="0.5"/>
+    <text x="408" y="130" fill="#0d1117">Q</text>
+    <!-- T -->
+    <rect x="440" y="135" width="16" height="16" rx="2" fill="#51cf66" stroke="#0d1117" stroke-width="0.5"/>
+    <text x="448" y="147" fill="#0d1117">T</text>
+    <!-- W -->
+    <rect x="470" y="162" width="16" height="16" rx="2" fill="#51cf66" stroke="#0d1117" stroke-width="0.5"/>
+    <text x="478" y="174" fill="#0d1117">W</text>
+    <!-- Z (rightmost) -->
+    <rect x="487" y="200" width="16" height="16" rx="2" fill="#51cf66" stroke="#0d1117" stroke-width="0.5"/>
+    <text x="495" y="212" fill="#0d1117">Z</text>
+    <!-- Ellipsis between shown blocks -->
+    <text x="203" y="185" fill="#51cf66" font-size="10">...</text>
+    <text x="226" y="150" fill="#51cf66" font-size="10">...</text>
+    <text x="260" y="128" fill="#51cf66" font-size="10">...</text>
+    <text x="310" y="116" fill="#51cf66" font-size="10">...</text>
+    <text x="382" y="116" fill="#51cf66" font-size="10">...</text>
+    <text x="422" y="128" fill="#51cf66" font-size="10">...</text>
+    <text x="458" y="150" fill="#51cf66" font-size="10">...</text>
+    <text x="482" y="185" fill="#51cf66" font-size="10">...</text>
+  </g>
+
+  <!-- Pick zone label -->
+  <text x="350" y="100" text-anchor="middle" font-size="12" font-weight="bold" fill="#51cf66">Pick Zone (Block Circle)</text>
+  <text x="350" y="88" text-anchor="middle" font-size="10" fill="#565f89">R = 350 mm, 26 blocks, delta_theta = 8 deg</text>
+
+  <!-- Writing arc (place zone) -->
+  <path d="M 245,370 A 170,170 0 0,0 370,415" fill="none" stroke="#e0af68" stroke-width="2.5"/>
+
+  <!-- Placed letters on writing arc -->
+  <g font-size="8" font-weight="bold" text-anchor="middle">
+    <rect x="237" y="362" width="16" height="16" rx="2" fill="#e0af68" stroke="#0d1117" stroke-width="0.5"/>
+    <text x="245" y="374" fill="#0d1117">H</text>
+    <rect x="257" y="375" width="16" height="16" rx="2" fill="#e0af68" stroke="#0d1117" stroke-width="0.5"/>
+    <text x="265" y="387" fill="#0d1117">E</text>
+    <rect x="280" y="385" width="16" height="16" rx="2" fill="#e0af68" stroke="#0d1117" stroke-width="0.5"/>
+    <text x="288" y="397" fill="#0d1117">L</text>
+    <rect x="305" y="393" width="16" height="16" rx="2" fill="#e0af68" stroke="#0d1117" stroke-width="0.5"/>
+    <text x="313" y="405" fill="#0d1117">L</text>
+    <rect x="330" y="400" width="16" height="16" rx="2" fill="#e0af68" stroke="#0d1117" stroke-width="0.5"/>
+    <text x="338" y="412" fill="#0d1117">O</text>
+    <!-- Empty slots -->
+    <rect x="355" y="407" width="16" height="16" rx="2" fill="none" stroke="#e0af68" stroke-width="1" stroke-dasharray="3,2"/>
+    <rect x="375" y="410" width="16" height="16" rx="2" fill="none" stroke="#e0af68" stroke-width="1" stroke-dasharray="3,2"/>
+  </g>
+
+  <!-- Place zone label -->
+  <text x="320" y="445" text-anchor="middle" font-size="12" font-weight="bold" fill="#e0af68">Place Zone (Writing Arc)</text>
+  <text x="320" y="460" text-anchor="middle" font-size="10" fill="#565f89">R_write = R + offset, angular_spacing = 4 deg</text>
+
+  <!-- Robot base -->
+  <circle cx="350" cy="280" r="15" fill="#30363d" stroke="#c0caf5" stroke-width="2"/>
+  <circle cx="350" cy="280" r="5" fill="#565f89"/>
+  <text x="350" y="305" text-anchor="middle" font-size="11" font-weight="bold" fill="#c0caf5">Robot Base</text>
+
+  <!-- Home position indicator -->
+  <circle cx="350" cy="240" r="6" fill="none" stroke="#f7768e" stroke-width="1.5"/>
+  <text x="350" y="238" text-anchor="middle" font-size="6" fill="#f7768e">H</text>
+  <text x="375" y="237" font-size="9" fill="#f7768e">Home</text>
+
+  <!-- Radius annotation to block circle -->
+  <line x1="350" y1="280" x2="448" y2="143" stroke="#7aa2f7" stroke-width="1" stroke-dasharray="5,3" marker-end="url(#arrW)"/>
+  <text x="420" y="200" font-size="10" fill="#7aa2f7" transform="rotate(-47,420,200)">R = 350 mm</text>
+
+  <!-- Legend -->
+  <g transform="translate(540,50)">
+    <rect x="0" y="0" width="145" height="115" rx="5" fill="#1a1b26" stroke="#30363d" stroke-width="1"/>
+    <text x="72" y="18" text-anchor="middle" font-size="10" font-weight="bold" fill="#c0caf5">Legend</text>
+    <rect x="10" y="28" width="12" height="10" rx="2" fill="#51cf66"/>
+    <text x="28" y="37" font-size="9" fill="#a9b1d6">Block (pick zone)</text>
+    <rect x="10" y="45" width="12" height="10" rx="2" fill="#e0af68"/>
+    <text x="28" y="54" font-size="9" fill="#a9b1d6">Placed letter</text>
+    <circle cx="16" cy="68" r="5" fill="#30363d" stroke="#c0caf5" stroke-width="1"/>
+    <text x="28" y="72" font-size="9" fill="#a9b1d6">Robot base</text>
+    <line x1="10" y1="85" x2="22" y2="85" stroke="#565f89" stroke-width="1.5" stroke-dasharray="4,3"/>
+    <text x="28" y="89" font-size="9" fill="#a9b1d6">Workspace boundary</text>
+    <circle cx="16" cy="102" r="4" fill="none" stroke="#f7768e" stroke-width="1"/>
+    <text x="28" y="106" font-size="9" fill="#a9b1d6">Home position</text>
+  </g>
+</svg>

--- a/images/rollings/sofi_cumulant_vs_moment.svg
+++ b/images/rollings/sofi_cumulant_vs_moment.svg
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400" viewBox="0 0 800 400">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, sans-serif; fill: #e6edf3; }
+      .title { font-size: 15px; font-weight: bold; fill: #58a6ff; }
+      .heading { font-size: 13px; font-weight: bold; }
+      .label { font-size: 11px; fill: #e6edf3; }
+      .sublabel { font-size: 9.5px; fill: #8b949e; }
+      .math { font-size: 11px; fill: #d2a8ff; font-style: italic; }
+      .emitter { fill: #7ee787; stroke: #7ee787; stroke-width: 1; }
+      .emitter-dim { fill: #7ee787; fill-opacity: 0.3; stroke: #7ee787; stroke-width: 0.5; stroke-opacity: 0.4; }
+      .conn-all { stroke: #f97583; stroke-width: 1.2; stroke-opacity: 0.5; }
+      .conn-genuine { stroke: #58a6ff; stroke-width: 2.5; }
+      .panel-bg { fill: #161b22; stroke: #30363d; stroke-width: 1; rx: 8; }
+      .minus { font-size: 28px; fill: #f0883e; font-weight: bold; }
+      .equals { font-size: 28px; fill: #8b949e; font-weight: bold; }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="400" fill="#0d1117"/>
+
+  <!-- Title -->
+  <text class="title" x="400" y="30" text-anchor="middle">Cumulant vs Moment: Why Cumulants Isolate Genuine Correlations</text>
+
+  <!-- LEFT Panel: Moment M_4 -->
+  <rect class="panel-bg" x="20" y="50" width="340" height="290"/>
+  <text class="heading" x="190" y="78" text-anchor="middle" fill="#f97583">Moment M_4</text>
+  <text class="sublabel" x="190" y="95" text-anchor="middle">All cross-terms included</text>
+
+  <!-- 4 emitters -->
+  <circle class="emitter" cx="100" cy="150" r="10"/>
+  <circle class="emitter" cx="260" cy="150" r="10"/>
+  <circle class="emitter" cx="100" cy="270" r="10"/>
+  <circle class="emitter" cx="260" cy="270" r="10"/>
+  <text class="label" x="100" y="130" text-anchor="middle">e1</text>
+  <text class="label" x="260" y="130" text-anchor="middle">e2</text>
+  <text class="label" x="100" y="295" text-anchor="middle">e3</text>
+  <text class="label" x="260" y="295" text-anchor="middle">e4</text>
+
+  <!-- ALL connections (cross-terms) -->
+  <!-- Pairs -->
+  <line class="conn-all" x1="110" y1="150" x2="250" y2="150"/>
+  <line class="conn-all" x1="100" y1="160" x2="100" y2="260"/>
+  <line class="conn-all" x1="260" y1="160" x2="260" y2="260"/>
+  <line class="conn-all" x1="110" y1="270" x2="250" y2="270"/>
+  <line class="conn-all" x1="108" y1="158" x2="252" y2="262"/>
+  <line class="conn-all" x1="108" y1="262" x2="252" y2="158"/>
+  <!-- Triple connections (faint) -->
+  <path d="M100,150 Q180,190 260,150 Q200,210 100,270" fill="none" stroke="#f97583" stroke-width="0.7" stroke-opacity="0.25"/>
+  <path d="M260,150 Q200,210 260,270 Q180,230 100,270" fill="none" stroke="#f97583" stroke-width="0.7" stroke-opacity="0.25"/>
+
+  <!-- Genuine 4-point connection (also present but hidden in noise) -->
+  <path d="M100,150 L260,150 L260,270 L100,270 Z" fill="none" stroke="#58a6ff" stroke-width="1" stroke-opacity="0.3" stroke-dasharray="4,3"/>
+
+  <text class="math" x="190" y="325" text-anchor="middle">M_4 = genuine + pairs + triples</text>
+
+  <!-- MINUS sign -->
+  <text class="minus" x="385" y="210" text-anchor="middle">-</text>
+  <text class="sublabel" x="385" y="230" text-anchor="middle">subtract</text>
+  <text class="sublabel" x="385" y="245" text-anchor="middle">lower-order</text>
+  <text class="sublabel" x="385" y="260" text-anchor="middle">products</text>
+
+  <!-- RIGHT Panel: Cumulant K_4 -->
+  <rect class="panel-bg" x="430" y="50" width="340" height="290"/>
+  <text class="heading" x="600" y="78" text-anchor="middle" fill="#58a6ff">Cumulant K_4</text>
+  <text class="sublabel" x="600" y="95" text-anchor="middle">Only genuine 4-point correlation</text>
+
+  <!-- 4 emitters -->
+  <circle class="emitter" cx="510" cy="150" r="10"/>
+  <circle class="emitter" cx="670" cy="150" r="10"/>
+  <circle class="emitter" cx="510" cy="270" r="10"/>
+  <circle class="emitter" cx="670" cy="270" r="10"/>
+  <text class="label" x="510" y="130" text-anchor="middle">e1</text>
+  <text class="label" x="670" y="130" text-anchor="middle">e2</text>
+  <text class="label" x="510" y="295" text-anchor="middle">e3</text>
+  <text class="label" x="670" y="295" text-anchor="middle">e4</text>
+
+  <!-- ONLY genuine 4-point connection -->
+  <line class="conn-genuine" x1="520" y1="150" x2="660" y2="150"/>
+  <line class="conn-genuine" x1="670" y1="160" x2="670" y2="260"/>
+  <line class="conn-genuine" x1="660" y1="270" x2="520" y2="270"/>
+  <line class="conn-genuine" x1="510" y1="260" x2="510" y2="160"/>
+
+  <text class="math" x="600" y="325" text-anchor="middle">K_4 = M_4 - 3*M_2^2  (clean!)</text>
+
+  <!-- Bottom equation -->
+  <text class="sublabel" x="400" y="370" text-anchor="middle">K_n[X+Y] = K_n[X] + K_n[Y] for independent X,Y -- cross-emitter terms vanish</text>
+  <text class="sublabel" x="400" y="388" text-anchor="middle">Result: PSF enters as U^n (not a mixture of lower powers) -- clean resolution gain of sqrt(n)</text>
+</svg>

--- a/images/rollings/sofi_vs_palm.svg
+++ b/images/rollings/sofi_vs_palm.svg
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400" viewBox="0 0 800 400">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, sans-serif; fill: #e6edf3; }
+      .title { font-size: 15px; font-weight: bold; fill: #58a6ff; }
+      .heading { font-size: 13px; font-weight: bold; }
+      .label { font-size: 11px; fill: #e6edf3; }
+      .sublabel { font-size: 9.5px; fill: #8b949e; }
+      .stat { font-size: 10px; fill: #d2a8ff; }
+      .panel-bg { fill: #161b22; stroke: #30363d; stroke-width: 1; rx: 8; }
+      .arrow { stroke: #58a6ff; stroke-width: 1.5; fill: none; }
+      .arrow-palm { stroke: #f97583; stroke-width: 1.5; fill: none; }
+      .box { fill: #21262d; stroke: #30363d; stroke-width: 1; rx: 4; }
+      .dot-dense { fill: #7ee787; fill-opacity: 0.7; }
+      .dot-sparse { fill: #f97583; }
+      .dot-off { fill: #30363d; stroke: #8b949e; stroke-width: 0.5; }
+    </style>
+    <marker id="arr-blue" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0,0 8,3 0,6" fill="#58a6ff"/>
+    </marker>
+    <marker id="arr-red" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0,0 8,3 0,6" fill="#f97583"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="400" fill="#0d1117"/>
+
+  <!-- Title -->
+  <text class="title" x="400" y="28" text-anchor="middle">SOFI vs PALM/STORM: Workflow Comparison</text>
+
+  <!-- LEFT: SOFI workflow -->
+  <rect class="panel-bg" x="15" y="42" width="375" height="345"/>
+  <text class="heading" x="202" y="66" text-anchor="middle" fill="#7ee787">SOFI Workflow</text>
+
+  <!-- Step 1: Dense labeling -->
+  <rect class="box" x="35" y="80" width="100" height="65"/>
+  <text class="label" x="85" y="98" text-anchor="middle">Dense</text>
+  <text class="label" x="85" y="112" text-anchor="middle">Labeling</text>
+  <!-- Dense dots -->
+  <circle class="dot-dense" cx="50" cy="130" r="2.5"/>
+  <circle class="dot-dense" cx="58" cy="126" r="2.5"/>
+  <circle class="dot-dense" cx="66" cy="132" r="2.5"/>
+  <circle class="dot-dense" cx="74" cy="127" r="2.5"/>
+  <circle class="dot-dense" cx="82" cy="131" r="2.5"/>
+  <circle class="dot-dense" cx="90" cy="125" r="2.5"/>
+  <circle class="dot-dense" cx="98" cy="130" r="2.5"/>
+  <circle class="dot-dense" cx="106" cy="128" r="2.5"/>
+  <circle class="dot-dense" cx="114" cy="133" r="2.5"/>
+  <circle class="dot-dense" cx="54" cy="136" r="2.5"/>
+  <circle class="dot-dense" cx="70" cy="138" r="2.5"/>
+  <circle class="dot-dense" cx="86" cy="137" r="2.5"/>
+  <circle class="dot-dense" cx="102" cy="135" r="2.5"/>
+
+  <!-- Arrow 1 -->
+  <line class="arrow" x1="140" y1="112" x2="160" y2="112" marker-end="url(#arr-blue)"/>
+
+  <!-- Step 2: Short stack -->
+  <rect class="box" x="165" y="80" width="100" height="65"/>
+  <text class="label" x="215" y="98" text-anchor="middle">Short Stack</text>
+  <text class="stat" x="215" y="115" text-anchor="middle">~100-1000</text>
+  <text class="stat" x="215" y="128" text-anchor="middle">frames</text>
+  <!-- Stack icon -->
+  <rect x="195" y="132" width="40" height="4" fill="#58a6ff" fill-opacity="0.3" stroke="#58a6ff" stroke-width="0.5"/>
+  <rect x="197" y="137" width="40" height="4" fill="#58a6ff" fill-opacity="0.2" stroke="#58a6ff" stroke-width="0.5"/>
+  <rect x="199" y="142" width="40" height="4" fill="#58a6ff" fill-opacity="0.1" stroke="#58a6ff" stroke-width="0.5"/>
+
+  <!-- Arrow 2 -->
+  <line class="arrow" x1="270" y1="112" x2="290" y2="112" marker-end="url(#arr-blue)"/>
+
+  <!-- Step 3: Cumulant -->
+  <rect class="box" x="295" y="80" width="80" height="65"/>
+  <text class="label" x="335" y="98" text-anchor="middle">Cumulant</text>
+  <text class="stat" x="335" y="115" text-anchor="middle">K_n(r)</text>
+  <text class="stat" x="335" y="130" text-anchor="middle">U^n(r)</text>
+
+  <!-- Arrow down -->
+  <line class="arrow" x1="335" y1="150" x2="335" y2="170" marker-end="url(#arr-blue)"/>
+
+  <!-- Step 4: Super-resolved -->
+  <rect class="box" x="265" y="175" width="140" height="50"/>
+  <text class="label" x="335" y="196" text-anchor="middle">Super-resolved Image</text>
+  <text class="stat" x="335" y="212" text-anchor="middle">sigma_eff = sigma/sqrt(n)</text>
+
+  <!-- SOFI stats box -->
+  <rect x="35" y="240" width="340" height="135" fill="#161b22" stroke="#30363d" stroke-width="0.5" rx="4"/>
+  <text class="label" x="55" y="260" fill="#7ee787">SOFI Characteristics:</text>
+  <text class="sublabel" x="55" y="278">Resolution: sqrt(n)x  (~1.4x for n=2, ~2x for n=4)</text>
+  <text class="sublabel" x="55" y="294">Frames: ~100-1000 (orders 2-3)</text>
+  <text class="sublabel" x="55" y="310">Labeling: HIGH density (many emitters per PSF)</text>
+  <text class="sublabel" x="55" y="326">Speed: FAST (seconds to minutes)</text>
+  <text class="sublabel" x="55" y="342">Probes: Any blinking fluorophore / QDots</text>
+  <text class="sublabel" x="55" y="358">Live cell: YES (low phototoxicity)</text>
+
+  <!-- RIGHT: PALM/STORM workflow -->
+  <rect class="panel-bg" x="410" y="42" width="375" height="345"/>
+  <text class="heading" x="597" y="66" text-anchor="middle" fill="#f97583">PALM/STORM Workflow</text>
+
+  <!-- Step 1: Sparse activation -->
+  <rect class="box" x="430" y="80" width="100" height="65"/>
+  <text class="label" x="480" y="98" text-anchor="middle">Sparse</text>
+  <text class="label" x="480" y="112" text-anchor="middle">Activation</text>
+  <!-- Sparse dots (few on, many off) -->
+  <circle class="dot-off" cx="445" cy="130" r="2.5"/>
+  <circle class="dot-sparse" cx="458" cy="126" r="3"/>
+  <circle class="dot-off" cx="470" cy="132" r="2.5"/>
+  <circle class="dot-off" cx="482" cy="127" r="2.5"/>
+  <circle class="dot-off" cx="494" cy="131" r="2.5"/>
+  <circle class="dot-sparse" cx="506" cy="125" r="3"/>
+  <circle class="dot-off" cx="518" cy="130" r="2.5"/>
+
+  <!-- Arrow 1 -->
+  <line class="arrow-palm" x1="535" y1="112" x2="555" y2="112" marker-end="url(#arr-red)"/>
+
+  <!-- Step 2: Long acquisition -->
+  <rect class="box" x="560" y="80" width="100" height="65"/>
+  <text class="label" x="610" y="98" text-anchor="middle">Long Acquis.</text>
+  <text class="stat" x="610" y="115" text-anchor="middle">~10000-50000</text>
+  <text class="stat" x="610" y="128" text-anchor="middle">frames</text>
+  <!-- Tall stack icon -->
+  <rect x="590" y="132" width="40" height="3" fill="#f97583" fill-opacity="0.4" stroke="#f97583" stroke-width="0.5"/>
+  <rect x="591" y="136" width="40" height="3" fill="#f97583" fill-opacity="0.3" stroke="#f97583" stroke-width="0.5"/>
+  <rect x="592" y="140" width="40" height="3" fill="#f97583" fill-opacity="0.2" stroke="#f97583" stroke-width="0.5"/>
+  <rect x="593" y="144" width="40" height="3" fill="#f97583" fill-opacity="0.1" stroke="#f97583" stroke-width="0.5"/>
+
+  <!-- Arrow down -->
+  <line class="arrow-palm" x1="610" y1="150" x2="610" y2="170" marker-end="url(#arr-red)"/>
+
+  <!-- Step 3: Localization -->
+  <rect class="box" x="555" y="175" width="110" height="35"/>
+  <text class="label" x="610" y="197" text-anchor="middle">PSF Fitting / Localization</text>
+
+  <!-- Arrow down -->
+  <line class="arrow-palm" x1="610" y1="215" x2="610" y2="230" marker-end="url(#arr-red)"/>
+
+  <!-- Step 4: Reconstruction -->
+  <rect class="box" x="540" y="235" width="140" height="35"/>
+  <text class="label" x="610" y="257" text-anchor="middle">Pointillist Reconstruction</text>
+
+  <!-- PALM stats box -->
+  <rect x="430" y="285" width="340" height="90" fill="#161b22" stroke="#30363d" stroke-width="0.5" rx="4"/>
+  <text class="label" x="450" y="305" fill="#f97583">PALM/STORM Characteristics:</text>
+  <text class="sublabel" x="450" y="323">Resolution: ~20 nm (unlimited in principle)</text>
+  <text class="sublabel" x="450" y="339">Frames: ~10000-50000 (sparse activation per frame)</text>
+  <text class="sublabel" x="450" y="355">Labeling: LOW density (single molecule per PSF)</text>
+  <text class="sublabel" x="450" y="371">Speed: SLOW (minutes to hours)</text>
+</svg>

--- a/images/rollings/sphersim_coordinates.svg
+++ b/images/rollings/sphersim_coordinates.svg
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" width="500" height="500">
+  <defs>
+    <radialGradient id="csphereGrad" cx="40%" cy="35%" r="55%">
+      <stop offset="0%" stop-color="#3a5a8a" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#1a2a4a" stop-opacity="0.35"/>
+    </radialGradient>
+    <marker id="axisArrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#bbb"/>
+    </marker>
+    <marker id="xArrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#ef5350"/>
+    </marker>
+    <marker id="yArrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#66bb6a"/>
+    </marker>
+    <marker id="zArrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#42a5f5"/>
+    </marker>
+    <marker id="rArrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#ffab40"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="500" height="500" fill="#0f1923" rx="8"/>
+
+  <!-- Title -->
+  <text x="250" y="30" text-anchor="middle" font-family="Arial, sans-serif" font-size="17" font-weight="bold" fill="#e0e0e0">AER Coordinate System</text>
+  <text x="250" y="48" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#999">Azimuth - Elevation - Radius</text>
+
+  <!-- Origin point -->
+  <circle cx="220" cy="260" r="4" fill="#fff"/>
+  <text x="210" y="278" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#ccc">O</text>
+
+  <!-- Semi-transparent sphere -->
+  <circle cx="220" cy="260" r="130" fill="url(#csphereGrad)" stroke="#5a8abf" stroke-width="1"/>
+
+  <!-- Equator ellipse -->
+  <ellipse cx="220" cy="260" rx="130" ry="40" fill="none" stroke="#5a8abf" stroke-width="0.8" stroke-dasharray="4,3"/>
+
+  <!-- X axis (right, red) -->
+  <line x1="220" y1="260" x2="380" y2="260" stroke="#ef5350" stroke-width="2" marker-end="url(#xArrow)"/>
+  <text x="390" y="264" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="#ef5350">X</text>
+
+  <!-- Y axis (forward-right perspective, green) -->
+  <line x1="220" y1="260" x2="135" y2="320" stroke="#66bb6a" stroke-width="2" marker-end="url(#yArrow)"/>
+  <text x="118" y="335" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="#66bb6a">Y</text>
+
+  <!-- Z axis (up, blue) -->
+  <line x1="220" y1="260" x2="220" y2="110" stroke="#42a5f5" stroke-width="2" marker-end="url(#zArrow)"/>
+  <text x="228" y="105" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="#42a5f5">Z</text>
+
+  <!-- Radius line to point P on sphere -->
+  <line x1="220" y1="260" x2="310" y2="180" stroke="#ffab40" stroke-width="2" stroke-dasharray="5,3" marker-end="url(#rArrow)"/>
+  <circle cx="310" cy="180" r="5" fill="#ffab40"/>
+  <text x="322" y="175" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#ffab40">P</text>
+
+  <!-- Radius label -->
+  <text x="276" y="210" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#ffab40" transform="rotate(-40,276,210)">R (radius)</text>
+
+  <!-- Projection onto equatorial plane -->
+  <line x1="310" y1="180" x2="310" y2="248" stroke="#888" stroke-width="1" stroke-dasharray="3,3"/>
+  <circle cx="310" cy="248" r="3" fill="#888"/>
+  <text x="322" y="252" font-family="Arial, sans-serif" font-size="9" fill="#888">P'</text>
+
+  <!-- Azimuth arc (horizontal angle from X axis to projection) -->
+  <path d="M 250 260 A 30 10 0 0 0 270 253" fill="none" stroke="#e040fb" stroke-width="2"/>
+  <text x="260" y="245" font-family="Arial, sans-serif" font-size="10" font-weight="bold" fill="#e040fb">az</text>
+
+  <!-- Azimuth label with arrow -->
+  <text x="305" y="290" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="#e040fb">Azimuth</text>
+  <text x="305" y="305" font-family="Arial, sans-serif" font-size="10" fill="#999">Horizontal angle</text>
+  <text x="305" y="318" font-family="Arial, sans-serif" font-size="10" fill="#999">around Z axis</text>
+
+  <!-- Elevation arc (vertical angle from equator to P) -->
+  <path d="M 300 252 A 35 35 0 0 0 310 225" fill="none" stroke="#26c6da" stroke-width="2"/>
+  <text x="315" y="240" font-family="Arial, sans-serif" font-size="10" font-weight="bold" fill="#26c6da">el</text>
+
+  <!-- Elevation label -->
+  <text x="370" y="210" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="#26c6da">Elevation</text>
+  <text x="370" y="225" font-family="Arial, sans-serif" font-size="10" fill="#999">Angle from</text>
+  <text x="370" y="238" font-family="Arial, sans-serif" font-size="10" fill="#999">equatorial plane</text>
+
+  <!-- ===== Conversion Formulas Box ===== -->
+  <rect x="25" y="355" width="450" height="125" rx="8" fill="#0a1420" fill-opacity="0.9" stroke="#3a5a7a" stroke-width="1"/>
+  <text x="250" y="378" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#ccc">Conversion Formulas</text>
+
+  <!-- AER -> XYZ -->
+  <text x="45" y="400" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#90caf9">AER to XYZ:</text>
+  <text x="55" y="418" font-family="monospace" font-size="11" fill="#ddd">x = R * cos(el) * cos(az)</text>
+  <text x="55" y="434" font-family="monospace" font-size="11" fill="#ddd">y = R * cos(el) * sin(az)</text>
+  <text x="55" y="450" font-family="monospace" font-size="11" fill="#ddd">z = R * sin(el)</text>
+
+  <!-- XYZ -> AER -->
+  <text x="280" y="400" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#ffab40">XYZ to AER:</text>
+  <text x="290" y="418" font-family="monospace" font-size="11" fill="#ddd">R  = sqrt(x^2+y^2+z^2)</text>
+  <text x="290" y="434" font-family="monospace" font-size="11" fill="#ddd">el = arcsin(z / R)</text>
+  <text x="290" y="450" font-family="monospace" font-size="11" fill="#ddd">az = arctan2(y, x)</text>
+
+  <!-- Bidirectional arrow between formulas -->
+  <line x1="240" y1="425" x2="275" y2="425" stroke="#64b5f6" stroke-width="1.5"/>
+  <polygon points="275,422 280,425 275,428" fill="#64b5f6"/>
+  <polygon points="240,422 235,425 240,428" fill="#64b5f6"/>
+
+  <!-- North/South labels on sphere -->
+  <text x="220" y="125" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#888">+Z (North)</text>
+  <text x="220" y="400" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#888" visibility="hidden">-Z (South)</text>
+</svg>

--- a/images/rollings/sphersim_epiboly.svg
+++ b/images/rollings/sphersim_epiboly.svg
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="400" viewBox="0 0 900 400">
+  <defs>
+    <style>
+      text { font-family: 'Segoe UI', Arial, sans-serif; }
+    </style>
+    <!-- Yolk gradient -->
+    <radialGradient id="yolkGrad" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#d4a017" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#b8860b" stop-opacity="0.3"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="900" height="400" fill="#0d1117"/>
+
+  <!-- Title -->
+  <text x="450" y="28" fill="#e6edf3" font-size="16" font-weight="bold" text-anchor="middle">Zebrafish Epiboly Stages (Side View Cross-Sections)</text>
+
+  <!-- Stage 1: 30% epiboly -->
+  <g transform="translate(30, 55)">
+    <text x="65" y="0" fill="#58a6ff" font-size="13" font-weight="bold" text-anchor="middle">30%</text>
+    <text x="65" y="14" fill="#8b949e" font-size="9" text-anchor="middle">~4.7 hpf</text>
+    <!-- Yolk cell (large circle) -->
+    <circle cx="65" cy="150" r="65" fill="url(#yolkGrad)" stroke="#b8860b" stroke-width="1"/>
+    <text x="65" y="175" fill="#b8860b" font-size="8" text-anchor="middle" opacity="0.7">Yolk</text>
+    <!-- YSL (yellow arc at margin) -->
+    <path d="M 18,118 A 65,65 0 0,1 112,118" fill="none" stroke="#d4a017" stroke-width="3" opacity="0.8"/>
+    <!-- EVL (red arc covering 30%) -->
+    <path d="M 8,130 A 68,68 0 0,1 122,130" fill="none" stroke="#da3633" stroke-width="2.5"/>
+    <!-- DEL (gray region under EVL) -->
+    <path d="M 15,125 C 25,95 45,80 65,78 C 85,80 105,95 115,125" fill="#8b949e" fill-opacity="0.25" stroke="none"/>
+    <!-- DFC cluster (cyan dots at dorsal margin) -->
+    <circle cx="55" cy="93" r="3" fill="#39d2e0"/>
+    <circle cx="65" cy="90" r="3" fill="#39d2e0"/>
+    <circle cx="75" cy="93" r="3" fill="#39d2e0"/>
+    <circle cx="60" cy="97" r="3" fill="#39d2e0"/>
+    <circle cx="70" cy="97" r="3" fill="#39d2e0"/>
+    <!-- Animal pole label -->
+    <text x="65" y="72" fill="#8b949e" font-size="7" text-anchor="middle">AP</text>
+    <!-- Margin arrow -->
+    <line x1="125" y1="130" x2="125" y2="145" stroke="#da3633" stroke-width="1" marker-end="url(#arrowRed)"/>
+  </g>
+
+  <!-- Stage 2: 50% epiboly -->
+  <g transform="translate(195, 55)">
+    <text x="65" y="0" fill="#58a6ff" font-size="13" font-weight="bold" text-anchor="middle">50%</text>
+    <text x="65" y="14" fill="#8b949e" font-size="9" text-anchor="middle">~5.3 hpf</text>
+    <circle cx="65" cy="150" r="65" fill="url(#yolkGrad)" stroke="#b8860b" stroke-width="1"/>
+    <text x="65" y="185" fill="#b8860b" font-size="8" text-anchor="middle" opacity="0.7">Yolk</text>
+    <!-- YSL -->
+    <path d="M 0,150 A 65,65 0 0,1 130,150" fill="none" stroke="#d4a017" stroke-width="3" opacity="0.8"/>
+    <!-- EVL covering 50% -->
+    <path d="M 0,150 A 68,68 0 0,1 130,150" fill="none" stroke="#da3633" stroke-width="2.5"/>
+    <!-- DEL -->
+    <path d="M 5,145 C 15,110 35,90 65,85 C 95,90 115,110 125,145" fill="#8b949e" fill-opacity="0.25" stroke="none"/>
+    <!-- DFC cluster slightly below top -->
+    <circle cx="52" cy="105" r="3" fill="#39d2e0"/>
+    <circle cx="62" cy="100" r="3" fill="#39d2e0"/>
+    <circle cx="72" cy="103" r="3" fill="#39d2e0"/>
+    <circle cx="57" cy="110" r="3" fill="#39d2e0"/>
+    <circle cx="67" cy="108" r="3" fill="#39d2e0"/>
+    <circle cx="77" cy="110" r="3" fill="#39d2e0"/>
+    <!-- Apical contact lines -->
+    <line x1="62" y1="100" x2="55" y2="90" stroke="#39d2e0" stroke-width="0.5" stroke-dasharray="2,1" opacity="0.6"/>
+    <line x1="72" y1="103" x2="78" y2="93" stroke="#39d2e0" stroke-width="0.5" stroke-dasharray="2,1" opacity="0.6"/>
+  </g>
+
+  <!-- Stage 3: 75% epiboly -->
+  <g transform="translate(360, 55)">
+    <text x="65" y="0" fill="#58a6ff" font-size="13" font-weight="bold" text-anchor="middle">75%</text>
+    <text x="65" y="14" fill="#8b949e" font-size="9" text-anchor="middle">~8.0 hpf</text>
+    <circle cx="65" cy="150" r="65" fill="url(#yolkGrad)" stroke="#b8860b" stroke-width="1"/>
+    <text x="65" y="200" fill="#b8860b" font-size="8" text-anchor="middle" opacity="0.7">Yolk</text>
+    <!-- YSL -->
+    <path d="M 12,185 A 65,65 0 0,1 118,185" fill="none" stroke="#d4a017" stroke-width="3" opacity="0.8"/>
+    <!-- EVL covering 75% -->
+    <path d="M 10,185 A 68,68 0 0,1 120,185" fill="none" stroke="#da3633" stroke-width="2.5"/>
+    <!-- DEL -->
+    <path d="M 8,180 C 15,140 35,100 65,90 C 95,100 115,140 122,180" fill="#8b949e" fill-opacity="0.2" stroke="none"/>
+    <!-- DFC cluster compacting -->
+    <circle cx="58" cy="140" r="3" fill="#39d2e0"/>
+    <circle cx="66" cy="136" r="3" fill="#39d2e0"/>
+    <circle cx="74" cy="140" r="3" fill="#39d2e0"/>
+    <circle cx="62" cy="145" r="3" fill="#39d2e0"/>
+    <circle cx="70" cy="145" r="3" fill="#39d2e0"/>
+    <circle cx="66" cy="150" r="3" fill="#39d2e0"/>
+    <!-- Weakened apical contacts (dashed, fading) -->
+    <line x1="66" y1="136" x2="60" y2="125" stroke="#39d2e0" stroke-width="0.4" stroke-dasharray="1,2" opacity="0.3"/>
+  </g>
+
+  <!-- Stage 4: 90% epiboly -->
+  <g transform="translate(525, 55)">
+    <text x="65" y="0" fill="#58a6ff" font-size="13" font-weight="bold" text-anchor="middle">90%</text>
+    <text x="65" y="14" fill="#8b949e" font-size="9" text-anchor="middle">~9.0 hpf</text>
+    <circle cx="65" cy="150" r="65" fill="url(#yolkGrad)" stroke="#b8860b" stroke-width="1"/>
+    <text x="65" y="208" fill="#b8860b" font-size="8" text-anchor="middle" opacity="0.7">Yolk</text>
+    <!-- YSL -->
+    <path d="M 30,205 A 65,65 0 0,1 100,205" fill="none" stroke="#d4a017" stroke-width="3" opacity="0.8"/>
+    <!-- EVL covering 90% -->
+    <path d="M 28,205 A 68,68 0 0,1 102,205" fill="none" stroke="#da3633" stroke-width="2.5"/>
+    <!-- DEL -->
+    <path d="M 5,195 C 12,150 30,110 65,95 C 100,110 118,150 125,195" fill="#8b949e" fill-opacity="0.15" stroke="none"/>
+    <!-- DFC cluster tight, near vegetal -->
+    <circle cx="60" cy="178" r="3" fill="#39d2e0"/>
+    <circle cx="68" cy="175" r="3" fill="#39d2e0"/>
+    <circle cx="64" cy="182" r="3" fill="#39d2e0"/>
+    <circle cx="72" cy="180" r="3" fill="#39d2e0"/>
+    <circle cx="56" cy="180" r="3" fill="#39d2e0"/>
+    <circle cx="64" cy="188" r="3" fill="#39d2e0"/>
+    <circle cx="72" cy="186" r="3" fill="#39d2e0"/>
+    <!-- No apical contacts -->
+  </g>
+
+  <!-- Stage 5: 100% epiboly -->
+  <g transform="translate(690, 55)">
+    <text x="65" y="0" fill="#58a6ff" font-size="13" font-weight="bold" text-anchor="middle">100%</text>
+    <text x="65" y="14" fill="#8b949e" font-size="9" text-anchor="middle">~10.3 hpf</text>
+    <circle cx="65" cy="150" r="65" fill="url(#yolkGrad)" stroke="#b8860b" stroke-width="1"/>
+    <!-- EVL fully enveloping -->
+    <circle cx="65" cy="150" r="67" fill="none" stroke="#da3633" stroke-width="2"/>
+    <!-- DEL thin layer -->
+    <circle cx="65" cy="150" r="63" fill="#8b949e" fill-opacity="0.1" stroke="none"/>
+    <!-- DFC rosette / KV at vegetal pole -->
+    <circle cx="65" cy="210" r="8" fill="none" stroke="#39d2e0" stroke-width="1.5"/>
+    <circle cx="61" cy="207" r="2" fill="#39d2e0"/>
+    <circle cx="69" cy="207" r="2" fill="#39d2e0"/>
+    <circle cx="65" cy="213" r="2" fill="#39d2e0"/>
+    <circle cx="60" cy="213" r="2" fill="#39d2e0"/>
+    <circle cx="70" cy="213" r="2" fill="#39d2e0"/>
+    <circle cx="65" cy="207" r="2" fill="#39d2e0"/>
+    <!-- KV label -->
+    <text x="65" y="230" fill="#39d2e0" font-size="8" text-anchor="middle">KV</text>
+    <!-- VP label -->
+    <text x="65" y="222" fill="#8b949e" font-size="7" text-anchor="middle" opacity="0.0">VP</text>
+  </g>
+
+  <!-- Legend -->
+  <g transform="translate(30, 330)">
+    <rect x="0" y="0" width="840" height="55" rx="5" fill="#161b22" stroke="#30363d" stroke-width="1"/>
+    <text x="15" y="18" fill="#e6edf3" font-size="10" font-weight="bold">Legend:</text>
+    <!-- EVL -->
+    <line x1="80" y1="14" x2="105" y2="14" stroke="#da3633" stroke-width="2.5"/>
+    <text x="110" y="18" fill="#e6edf3" font-size="9">EVL (Enveloping Layer)</text>
+    <!-- DEL -->
+    <rect x="250" y="8" width="20" height="10" fill="#8b949e" fill-opacity="0.3"/>
+    <text x="275" y="18" fill="#e6edf3" font-size="9">DEL (Deep Cell Layer)</text>
+    <!-- YSL -->
+    <line x1="420" y1="14" x2="445" y2="14" stroke="#d4a017" stroke-width="3" opacity="0.8"/>
+    <text x="450" y="18" fill="#e6edf3" font-size="9">YSL (Yolk Syncytial Layer)</text>
+    <!-- DFC -->
+    <circle cx="618" cy="13" r="3" fill="#39d2e0"/>
+    <text x="627" y="18" fill="#e6edf3" font-size="9">DFC cluster</text>
+    <!-- Yolk -->
+    <circle cx="720" cy="13" r="6" fill="url(#yolkGrad)" stroke="#b8860b" stroke-width="0.5"/>
+    <text x="732" y="18" fill="#e6edf3" font-size="9">Yolk cell</text>
+    <!-- Timing note -->
+    <text x="15" y="42" fill="#8b949e" font-size="8">hpf = hours post-fertilization at 28.5C. Timing from Kimmel et al. (1995). DFC specification, delamination, and KV formation based on Oteiza et al. (2008) and Ablooglu et al. (2021).</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
26 files changed: 15 SVGs from project repos + 3 new rollings + 4 enriched rollings + 4 enriched posts.

### New SVGs (from project repos)
Cell models, coordinate systems, Fourier optics, information theory, octree partitioning, force models, DH reference frames, Helmholtz reciprocity, resolvability curves, epiboly stages, and more.

### New rollings
- **Eight Repos, One Night** — cross-repo bug fixing with Hamiltonian energy equation
- **Light Goes Both Ways** — Helmholtz reciprocity and SVD transport matrices
- **Where Can the Robot Reach?** — Scorbot III workspace with DH kinematics chain

### Enriched rollings (2009-2015)
SOFI, entropy sampling, haptic collision, optical tweezers — each now has project SVGs and equation cards.

### Enriched posts
MathGeo, PhD dissertation, SOFI Chile, Crusher platform — SVGs and equation cards added.

Addresses #30 and #31

## Test plan
- [ ] All 15 copied SVGs render correctly
- [ ] Equation cards display with dark background
- [ ] New rollings appear in correct chronological order
- [ ] Enriched posts maintain existing content + new visuals

---

@codex — Review only! 26 files, 15 SVGs copied from project repos. Check that SVG paths match the actual filenames, verify equation card HTML renders, and see if any SVG has XML issues. Pouvez-vous trouver une erreur dans 26 fichiers? 🇫🇷📏

🤖 Generated with [Claude Code](https://claude.com/claude-code)