### PR TITLE
Feat: Add 2 rollings + 1 post on cross-surface sync system

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "additionalDirectories": [
+      "C:\\Users\\fsant\\.claude\\projects\\d---Repos--SCIENCE-fsantibanezleal-github-io"
+    ]
+  }
+}

--- a/_posts/2026-04-20-Four-Surfaces-One-Story.md
+++ b/_posts/2026-04-20-Four-Surfaces-One-Story.md
@@ -1,0 +1,98 @@
+---
+title: 'Four surfaces, one story — running a personal portfolio like a data pipeline'
+date: 2026-04-20
+permalink: /posts/2026/04/four-surfaces-one-story/
+tags:
+  - portfolio
+  - management
+  - infrastructure
+  - runbooks
+  - meta
+---
+
+Four surfaces, one story
+======
+
+For a long time my portfolio was a website I edited when I remembered. This week it became a data pipeline.
+
+This post is about the shift — what changed, why it mattered, and what the finished architecture looks like. The honest version is that I should have done this years ago. The useful version is that the reframing only became possible once I had lived the same reframing in my day job: from writing models to owning their business outcomes, and then to accounting for them quarter after quarter. The same mental model that turns a research script into a production system also turns a personal website into a system. It just took me a while to notice I had not applied it to myself.
+
+## The fragmentation problem
+
+A professional identity online is never one artifact. Mine turned out to be four plus one upstream asset vault.
+
+![Portfolio sync flow — five surfaces, two canonical sources](/images/projects/portfolio_sync_flow.svg)
+
+The **portfolio site** (`FASL_WEB_Portfolio`) is where every project lives in its richest form. Astro, Tailwind, bilingual by construction — the Zod schema refuses to build if any field is missing its English or Spanish twin. KPIs, technical metrics, business context, strategic value, stack, diagrams, screenshots. Twenty-two projects, five tabs each.
+
+The **personal website** (this one, `fsantibanezleal.github.io`) is the first-impression surface. Bio, publications, talks, rollings, posts, a curated subset of the portfolio. Jekyll, English only, academic theme. What you are reading now lives here.
+
+The **online CV** (`online-cv`) is the shareable single-page CV. YAML-driven, Orbit theme, twenty-two project entries compressed to title + link + tagline each. The recruiter link, the LinkedIn bio link, the email signature link.
+
+The **writing-resume** (`FASL_Writing_Resume`) is LaTeX. Four variants — Industry Spanish, Industry English, Research Spanish, Research English — built with `xelatex` through a Makefile, the PDFs committed alongside the sources so anyone cloning gets both without needing a full LaTeX stack.
+
+The upstream vault is **FASL_GTASKS**: logos at three versions (v3 is canonical), favicons at every size a browser might ask for, OG images, a canonical palette, templates for email signatures and slide decks. Every consumer above holds a copy — not a symlink, not a submodule — so deploys stay self-contained.
+
+Four surfaces, five if you count GTASKS. Each with its own repository, its own stack, its own voice.
+
+## Canonical sources and mirrors
+
+The temptation when you have five repos is to think of them as peers. That leads to chaos. The portfolio site's Mine Pile Visualizer entry is worded one way, the online CV's is worded another, the research CV's is worded a third, the personal website's portfolio card is worded a fourth. All four are "correct." None of them is authoritative. Two weeks later you do not remember which one you updated last.
+
+The fix is to pick canonicals. The portfolio site is canonical for product content — it has the richest schema, it enforces bilingual, it is the one place where the challenge paragraph and the KPI table live in full. The writing-resume is canonical for CV text — experience bullets, education entries, honors. GTASKS is canonical for visual identity. Everything else is a mirror.
+
+Once the canonicals are named, the direction of flow becomes obvious.
+
+<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
+<strong style="color:#e07830;">Direction of flow:</strong><br/>
+Product content: portfolio site → personal website card + online CV entry + research CV cventry<br/>
+CV text: writing-resume → online CV + personal website CV summary<br/>
+Visual identity: GTASKS → every visual consumer (copy, not link)<br/>
+<span style="color:#5a9ac0;font-size:13px;">No circular edits. The canonical wins every tie. If the mirror disagrees, the mirror is stale.</span>
+</div>
+
+## The runbook layer
+
+Auto-sync was the obvious next step, and I deliberately did not take it.
+
+Each surface has its own voice. The portfolio site is narrative — challenge, approach, strategic value. The personal website portfolio card is reflective — what the product meant, how it evolved. The online CV is terse — title, link, one-line tagline. The research CV is compressed — one bullet that has to earn its two lines by carrying the single most specific technical claim that makes a reader pause.
+
+A template would flatten them. The compression from portfolio excerpt to CV bullet is not a formatting transformation — it is an editorial call about which technical claim survives. You cannot automate that. You can document it.
+
+So the `portfolio/` folder in my management repo holds five runbooks, one per target surface (plus one for branding). Each runbook explains the exact file, the exact field, the exact convention for adding or updating content in that specific surface. When I add a new project, I follow them in sequence: portfolio site first (canonical), then three mirrors. Two hours of work. Four separate pull requests across four separate repositories, because they are separate git histories and batching them would hide what changed where.
+
+The runbooks are manual by design but surface-by-surface explicit. Future me — or anyone coming in fresh — follows them step by step and nothing is left to memory.
+
+## The drift audit
+
+The point of naming canonicals is to make drift detectable. The point of writing runbooks is to make drift correctable on a schedule.
+
+The first audit, run as soon as the folder existed, found three projects present in the portfolio site and personal website but missing from either the online CV, the research CV, or both. This is exactly the kind of drift that accumulates silently when there is no defined flow.
+
+![Drift matrix — three projects before the sync](/images/projects/portfolio_drift_matrix.svg)
+
+Mine Pile Visualizer and FeelIT 2.0 — both shipped in the last two months — had landed everywhere except the LaTeX research CV. The PhD thesis itself had slipped out of the online CV at some point and was never copied into the LaTeX research variants, even though it was sitting right there in the portfolio site and on the personal website's `_portfolio/` folder. Three projects, five missing entries total.
+
+Closing the drift took an afternoon. Six new `\cventry` blocks in the LaTeX Research variants (three each in EN and ES), both PDFs rebuilt at the same six-page length without overflow. One YAML entry added to the online CV, positioned next to its algorithmic companion so the narrative flowed. Two pull requests, two merges, and the matrix went green.
+
+The interesting part was not the work. It was that the audit surfaced the gaps in minutes. Before this week, I would have noticed the LaTeX CV was out of date the next time I sent it to a recruiter — weeks or months later, and probably in a rush. Having a defined flow means the fix belongs to a regular cadence instead of a crisis.
+
+## The shift in framing
+
+Ten years ago the same work would have looked different. I would have treated each surface as a separate task, edited them directly without a plan, and trusted memory to keep track. The Windows Forms / OpenGL version of my portfolio management, if you will. It worked. Kind of. The surfaces drifted, the branding was stale in two of them, and the research CV was a year behind.
+
+Then a decade of building production systems happened. Canonical tables. Derived marts. Explicit ownership. Drift checks in CI. The habit of asking "where does this come from, and what depends on it?" before editing anything. That habit is obvious in a data team. It is less obvious when the "data" is your own career narrative scattered across five repositories you own alone.
+
+The runbooks are not the artifact that matters. The artifact is the reframing: my portfolio is five repositories, not one website, and the connections between them are a pipeline that needs the same discipline as any other pipeline I would design professionally. Canonicals, mirrors, runbooks, drift audits, cadence. The only difference from a production data stack is that I am both the engineer and the user, and the audience is whoever reads the link.
+
+![Mining optimization — the business-impact lens applied to technical work](/images/projects/mining_optimization.svg)
+
+## What comes next
+
+The current runbooks cover adding and updating content. Retirement is covered too — archive in place, never delete the slug, because the URL is permanent history.
+
+What is not yet covered is the surface that does not exist yet. LinkedIn, for example, is a manual paste of a PDF from the writing-resume plus a summary written fresh. That is a surface without a runbook. Eventually it will get one. The same goes for the occasional outbound PDF sent to a specific recruiter with tailored project selection — today that is a judgment call, tomorrow maybe a Flow G in the writing-resume runbook.
+
+For now the five that exist are synchronized, the runbooks are committed, and the cadence is defined. The next drift audit is scheduled for the next heavy cycle. If the matrix is green, good. If not, the flow is obvious: pick the stalest surface, follow the runbook, merge the PR, move on.
+
+The whole thing, including the runbook folder, is in [CAOS_MANAGE#17](https://github.com/fsantibanezleal/CAOS_MANAGE/pull/17). The two content-sync pull requests are [FASL_Writing_Resume#37](https://github.com/fsantibanezleal/FASL_Writing_Resume/pull/37) and [online-cv#24](https://github.com/fsantibanezleal/online-cv/pull/24). The two rollings from today are the short version of this post: [The Sync Runbook](/rollings/2026/04/sync-runbook/) and [Two Lines](/rollings/2026/04/two-lines/).

--- a/_rollings/2026-04-20-01-sync-runbook.md
+++ b/_rollings/2026-04-20-01-sync-runbook.md
@@ -1,0 +1,30 @@
+---
+title: 'The Sync Runbook'
+date: 2026-04-20
+permalink: /rollings/2026/04/sync-runbook/
+tags:
+  - Portfolio
+  - Management
+  - Meta
+  - Runbooks
+  - CAOS
+---
+
+The Sync Runbook
+======
+
+Spent the afternoon carving out a new folder in my private management repo: `portfolio/`. Not a product — a flow. Four public surfaces (this website, the online CV, the portfolio site, the LaTeX resumes) plus one upstream brand vault (GTASKS) that every visual consumer quietly depends on. They each have their own voice, their own cadence, their own schema. What they did not have, until today, was a map describing how content moves between them when something changes.
+
+![Portfolio sync flow — five surfaces, two canonical sources](/images/projects/portfolio_sync_flow.svg)
+
+For a long time I treated my portfolio like content. A new project? Paste it into whichever surface I was editing at the moment, remember to update the others later. That "later" was doing a lot of work. The online CV lagged the portfolio site. The research CV trailed both. Something would always be a little bit out of date, and the only person noticing was me.
+
+<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
+<strong style="color:#e07830;">Five runbooks under one folder:</strong><br/>
+sync-portfolio-web · sync-personal-website · sync-online-cv · sync-writing-resume · sync-branding-gtasks<br/>
+<span style="color:#5a9ac0;font-size:13px;">Plus surfaces.md, content-model.md, cadence.md — the vocabulary, the schema, and the beat.</span>
+</div>
+
+The shift in framing was from "content management" to "data pipeline." Portfolio site is the canonical source for product content; writing-resume is canonical for CV text; GTASKS is canonical for visual identity. Everything else is a mirror. Each mirror has its own runbook that explains exactly which file, which field, which convention. No auto-sync — I want to keep each surface's voice, and flattening them into one template would lose what makes them useful. Manual, but documented. That's the difference.
+
+The code at my day job has the same shape: canonical tables, derived marts, explicit ownership, drift checks. It felt strange not to have the same discipline for the website I had been running for ten years. Now I do. The runbooks are in [CAOS_MANAGE#17](https://github.com/fsantibanezleal/CAOS_MANAGE/pull/17), along with a cadence doc that says when to sync what.

--- a/_rollings/2026-04-20-02-two-lines.md
+++ b/_rollings/2026-04-20-02-two-lines.md
@@ -1,0 +1,30 @@
+---
+title: 'Two Lines'
+date: 2026-04-20
+permalink: /rollings/2026/04/two-lines/
+tags:
+  - CV
+  - Research
+  - LaTeX
+  - Portfolio
+  - Compression
+---
+
+Two Lines
+======
+
+There is a specific kind of editing that happens when you take a project from the portfolio site and land it on the Research CV. The portfolio entry for Mine Pile Visualizer carries a bilingual excerpt, a challenge paragraph, an approach paragraph, three KPIs with baselines and results and impact framing, four technical metrics, a stack of eleven libraries, and a long Markdown body. The CV entry for the same project is one bullet. Two lines of LaTeX, wrapped to fit the column.
+
+![Material tracking — the portfolio-site source](/images/projects/material_tracking.svg)
+
+Everything you care about as a developer — the instanced mesh rendering trick, the Apache Arrow schema, the Zod runtime contracts, the dagre auto-layout — collapses into a phrase. *"Local-first web platform for mining circuit topology, 3D stockpile voxels, and live material state."* The rest is compressed into what the bullet has to earn: the one specific technical claim that makes the reader's eyes stop for a moment. Sub-second loading of thousands of voxels via React Three Fiber. That's the hook.
+
+<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
+<strong style="color:#e07830;">The compression ratio:</strong><br/>
+portfolio excerpt (160 chars) + challenge (430) + approach (390) + 3 KPI rows + 4 metric rows → 1 cventry bullet (~250 chars)<br/>
+<span style="color:#5a9ac0;font-size:13px;">Ten years ago I would have written the CV bullet first, from what I remembered. Today the compression direction runs the other way: rich source, curated output.</span>
+</div>
+
+The Research CV was missing three projects today — Mine Pile Visualizer, FeelIT 2.0, and the PhD Thesis itself. All three were already on the portfolio site, the online CV, the personal website. Only the LaTeX CV was behind, because it is the surface I touch least often. The drift audit that came out of the [sync runbook](/rollings/2026/04/sync-runbook/) caught it. Two hours later, six new `\cventry` blocks (three each in the EN and ES variants), both PDFs rebuilt, same six-page length, no overflow. [FASL_Writing_Resume#37](https://github.com/fsantibanezleal/FASL_Writing_Resume/pull/37).
+
+The harder edit is not the LaTeX. It's picking which technical claim survives the compression. That one you cannot automate.

--- a/images/projects/portfolio_drift_matrix.svg
+++ b/images/projects/portfolio_drift_matrix.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 380" width="900" height="380" role="img" aria-labelledby="title desc">
+  <title id="title">Portfolio drift matrix — three projects before the sync</title>
+  <desc id="desc">Three projects (Mine Pile Visualizer, FeelIT 2.0, PhD Thesis) audited across the four surfaces. Check marks show where the project was present before the April 2026 sync; gaps show the drift that was closed.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0a1628"/>
+      <stop offset="100%" stop-color="#111c33"/>
+    </linearGradient>
+    <style>
+      .title { font: 700 18px 'Segoe UI', Arial, sans-serif; fill: #e8772e; letter-spacing: 1.2px; }
+      .subtitle { font: 400 12px 'Segoe UI', Arial, sans-serif; fill: #8b9bb0; }
+      .colHeader { font: 700 12px 'Segoe UI', Arial, sans-serif; fill: #ffffff; letter-spacing: 0.8px; }
+      .rowLabel { font: 600 13px 'Segoe UI', Arial, sans-serif; fill: #e6edf3; }
+      .check { font: 700 22px 'Segoe UI', Arial, sans-serif; fill: #5cb85c; text-anchor: middle; }
+      .miss { font: 700 22px 'Segoe UI', Arial, sans-serif; fill: #e06c6c; text-anchor: middle; }
+      .added { font: 700 22px 'Segoe UI', Arial, sans-serif; fill: #e8772e; text-anchor: middle; }
+      .caption { font: 400 11px 'Segoe UI', Arial, sans-serif; fill: #7db8e0; }
+      .mono { font: 400 10px Consolas, monospace; fill: #a6b8cf; }
+    </style>
+  </defs>
+
+  <rect width="900" height="380" fill="url(#bg)" rx="8"/>
+
+  <text x="450" y="34" class="title" text-anchor="middle">DRIFT MATRIX — THREE PROJECTS, FOUR SURFACES</text>
+  <text x="450" y="54" class="subtitle" text-anchor="middle">Before the April 2026 sync: ✓ present · ✗ missing · ⊕ added by the sync</text>
+
+  <!-- Table headers -->
+  <rect x="60" y="78" width="780" height="36" rx="4" fill="#1e3a5f" stroke="#2a6aa8" stroke-width="1"/>
+  <text x="110" y="101" class="colHeader">PROJECT</text>
+  <text x="360" y="101" class="colHeader" text-anchor="middle">portfolio site</text>
+  <text x="490" y="101" class="colHeader" text-anchor="middle">personal website</text>
+  <text x="620" y="101" class="colHeader" text-anchor="middle">online CV</text>
+  <text x="760" y="101" class="colHeader" text-anchor="middle">writing-resume</text>
+
+  <!-- Row 1 — Mine Pile Visualizer -->
+  <rect x="60" y="122" width="780" height="58" rx="4" fill="#152132" stroke="#1e3a5f" stroke-width="1"/>
+  <text x="75" y="148" class="rowLabel">Mine Pile Visualizer</text>
+  <text x="75" y="167" class="mono">Next.js 16 · React Three Fiber · Apache Arrow</text>
+  <text x="360" y="159" class="check">✓</text>
+  <text x="490" y="159" class="check">✓</text>
+  <text x="620" y="159" class="check">✓</text>
+  <text x="760" y="159" class="added">⊕</text>
+
+  <!-- Row 2 — FeelIT 2.0 -->
+  <rect x="60" y="186" width="780" height="58" rx="4" fill="#152132" stroke="#1e3a5f" stroke-width="1"/>
+  <text x="75" y="212" class="rowLabel">FeelIT 2.0 — Haptic Accessibility Workbench</text>
+  <text x="75" y="231" class="mono">Python · FastAPI · Three.js · native haptic pilot</text>
+  <text x="360" y="223" class="check">✓</text>
+  <text x="490" y="223" class="check">✓</text>
+  <text x="620" y="223" class="check">✓</text>
+  <text x="760" y="223" class="added">⊕</text>
+
+  <!-- Row 3 — PhD Thesis -->
+  <rect x="60" y="250" width="780" height="58" rx="4" fill="#152132" stroke="#1e3a5f" stroke-width="1"/>
+  <text x="75" y="276" class="rowLabel">PhD Thesis — Information-Theoretic Sampling</text>
+  <text x="75" y="295" class="mono">AdSEMES · submodularity · Math.Geo. + NRR (2019–2020)</text>
+  <text x="360" y="287" class="check">✓</text>
+  <text x="490" y="287" class="check">✓</text>
+  <text x="620" y="287" class="added">⊕</text>
+  <text x="760" y="287" class="added">⊕</text>
+
+  <!-- Legend -->
+  <rect x="60" y="324" width="780" height="36" rx="4" fill="#0a1628" stroke="#1e3a5f" stroke-width="1"/>
+  <text x="80" y="347" class="check">✓</text>
+  <text x="95" y="345" class="caption" style="fill:#9fb0c3;">already present before sync</text>
+  <text x="290" y="347" class="miss">✗</text>
+  <text x="305" y="345" class="caption" style="fill:#9fb0c3;">missing (the drift)</text>
+  <text x="460" y="347" class="added">⊕</text>
+  <text x="475" y="345" class="caption" style="fill:#e8772e; font-weight:700;">added by the April 2026 sync</text>
+  <text x="760" y="345" class="caption" style="fill:#8b9bb0;">5 entries closed</text>
+</svg>

--- a/images/projects/portfolio_sync_flow.svg
+++ b/images/projects/portfolio_sync_flow.svg
@@ -1,0 +1,107 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 520" width="900" height="520" role="img" aria-labelledby="title desc">
+  <title id="title">Portfolio sync flow — five surfaces</title>
+  <desc id="desc">Canonical sources (portfolio site for product content, writing-resume for CV text) feed three mirrors (personal website, online CV, and CV summary) while branding flows from FASL_GTASKS into every visual consumer.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0a1628"/>
+      <stop offset="100%" stop-color="#111c33"/>
+    </linearGradient>
+    <linearGradient id="canonical" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#e8772e"/>
+      <stop offset="100%" stop-color="#c45a1a"/>
+    </linearGradient>
+    <linearGradient id="mirror" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1e3a5f"/>
+      <stop offset="100%" stop-color="#0f2440"/>
+    </linearGradient>
+    <linearGradient id="branding" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2a6aa8"/>
+      <stop offset="100%" stop-color="#174a7c"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="3" stdDeviation="4" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="5" orient="auto">
+      <path d="M0 0 L10 5 L0 10 Z" fill="#7db8e0"/>
+    </marker>
+    <marker id="arrowOrange" markerWidth="10" markerHeight="10" refX="9" refY="5" orient="auto">
+      <path d="M0 0 L10 5 L0 10 Z" fill="#e8772e"/>
+    </marker>
+    <style>
+      .title { font: 700 18px 'Segoe UI', Arial, sans-serif; fill: #e8772e; letter-spacing: 1.2px; }
+      .subtitle { font: 400 12px 'Segoe UI', Arial, sans-serif; fill: #8b9bb0; }
+      .boxTitle { font: 700 14px 'Segoe UI', Arial, sans-serif; fill: #ffffff; }
+      .boxSub { font: 400 11px 'Segoe UI', Arial, sans-serif; fill: #c5d2e1; }
+      .mono { font: 400 10px Consolas, monospace; fill: #a6b8cf; }
+      .badge { font: 700 10px 'Segoe UI', Arial, sans-serif; fill: #0a1628; letter-spacing: 1px; }
+      .arrowLabel { font: 400 10px 'Segoe UI', Arial, sans-serif; fill: #7db8e0; }
+    </style>
+  </defs>
+
+  <rect width="900" height="520" fill="url(#bg)" rx="8"/>
+
+  <text x="450" y="36" class="title" text-anchor="middle">PORTFOLIO SYNC FLOW — FIVE SURFACES, TWO CANONICAL SOURCES</text>
+  <text x="450" y="58" class="subtitle" text-anchor="middle">Product content flows from the portfolio site. CV text flows from writing-resume. Branding flows from GTASKS into all visual consumers.</text>
+
+  <!-- GTASKS upstream (top) -->
+  <rect x="360" y="90" width="180" height="60" rx="6" fill="url(#branding)" stroke="#3d7ec0" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="450" y="115" class="boxTitle" text-anchor="middle">FASL_GTASKS</text>
+  <text x="450" y="133" class="boxSub" text-anchor="middle">logos · favicons · OG · palette</text>
+  <rect x="378" y="94" width="70" height="16" rx="3" fill="#2a6aa8"/>
+  <text x="413" y="105" class="badge" text-anchor="middle">BRANDING</text>
+
+  <!-- Canonical sources (left + center-left) -->
+  <rect x="70" y="220" width="220" height="78" rx="6" fill="url(#canonical)" stroke="#e8772e" stroke-width="2" filter="url(#shadow)"/>
+  <text x="180" y="248" class="boxTitle" text-anchor="middle">FASL_WEB_Portfolio</text>
+  <text x="180" y="266" class="boxSub" text-anchor="middle">Astro · bilingual · Zod schema</text>
+  <text x="180" y="284" class="mono" text-anchor="middle">22 products · canonical</text>
+  <rect x="82" y="224" width="80" height="16" rx="3" fill="#0a1628"/>
+  <text x="122" y="235" class="badge" text-anchor="middle">CANONICAL</text>
+
+  <rect x="610" y="220" width="220" height="78" rx="6" fill="url(#canonical)" stroke="#e8772e" stroke-width="2" filter="url(#shadow)"/>
+  <text x="720" y="248" class="boxTitle" text-anchor="middle">FASL_Writing_Resume</text>
+  <text x="720" y="266" class="boxSub" text-anchor="middle">LaTeX · 4 variants · PDFs</text>
+  <text x="720" y="284" class="mono" text-anchor="middle">Industry ES/EN · Research ES/EN</text>
+  <rect x="622" y="224" width="80" height="16" rx="3" fill="#0a1628"/>
+  <text x="662" y="235" class="badge" text-anchor="middle">CANONICAL</text>
+
+  <!-- Mirrors (bottom row) -->
+  <rect x="70" y="400" width="220" height="70" rx="6" fill="url(#mirror)" stroke="#2a6aa8" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="180" y="428" class="boxTitle" text-anchor="middle">personal website</text>
+  <text x="180" y="446" class="boxSub" text-anchor="middle">Jekyll · _portfolio · rollings · posts</text>
+  <text x="180" y="462" class="mono" text-anchor="middle">fsantibanezleal.github.io</text>
+
+  <rect x="340" y="400" width="220" height="70" rx="6" fill="url(#mirror)" stroke="#2a6aa8" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="450" y="428" class="boxTitle" text-anchor="middle">online CV</text>
+  <text x="450" y="446" class="boxSub" text-anchor="middle">Jekyll · Orbit theme · data.yml</text>
+  <text x="450" y="462" class="mono" text-anchor="middle">/online-cv/</text>
+
+  <rect x="610" y="400" width="220" height="70" rx="6" fill="url(#mirror)" stroke="#2a6aa8" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="720" y="428" class="boxTitle" text-anchor="middle">CV summary slot</text>
+  <text x="720" y="446" class="boxSub" text-anchor="middle">personal website _pages/cv.md</text>
+  <text x="720" y="462" class="mono" text-anchor="middle">derived from LaTeX</text>
+
+  <!-- Arrows: canonical → mirrors -->
+  <!-- portfolio-web → personal-web -->
+  <path d="M 180 298 L 180 400" stroke="#e8772e" stroke-width="2" fill="none" marker-end="url(#arrowOrange)"/>
+  <!-- portfolio-web → online-cv (projects) -->
+  <path d="M 240 298 C 300 340, 380 360, 420 400" stroke="#e8772e" stroke-width="2" fill="none" marker-end="url(#arrowOrange)"/>
+  <!-- writing-resume → online-cv (bulk) -->
+  <path d="M 660 298 C 600 340, 520 360, 480 400" stroke="#e8772e" stroke-width="2" fill="none" marker-end="url(#arrowOrange)"/>
+  <!-- writing-resume → cv-summary -->
+  <path d="M 720 298 L 720 400" stroke="#e8772e" stroke-width="2" fill="none" marker-end="url(#arrowOrange)"/>
+
+  <!-- Arrows: GTASKS → everyone visual -->
+  <path d="M 430 150 C 400 190, 300 200, 230 220" stroke="#7db8e0" stroke-width="1.4" fill="none" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+  <path d="M 470 150 C 500 190, 600 200, 670 220" stroke="#7db8e0" stroke-width="1.4" fill="none" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+  <path d="M 420 150 C 360 240, 280 340, 230 400" stroke="#7db8e0" stroke-width="1.4" fill="none" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+  <path d="M 450 150 L 450 400" stroke="#7db8e0" stroke-width="1.4" fill="none" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+
+  <!-- Legend -->
+  <rect x="70" y="492" width="760" height="22" rx="4" fill="#0a1628" stroke="#1e3a5f" stroke-width="1"/>
+  <line x1="86" y1="503" x2="106" y2="503" stroke="#e8772e" stroke-width="2"/>
+  <text x="115" y="507" class="arrowLabel">content flow (canonical → mirror)</text>
+  <line x1="320" y1="503" x2="340" y2="503" stroke="#7db8e0" stroke-width="1.4" stroke-dasharray="4,3"/>
+  <text x="349" y="507" class="arrowLabel">branding asset copy (GTASKS → consumer)</text>
+  <text x="580" y="507" class="arrowLabel" style="fill:#e8772e; font-weight:700;">manual runbooks, no auto-sync</text>
+</svg>


### PR DESCRIPTION
## Summary

- 2 rollings + 1 long-form post + 2 new SVGs
- Documents the Phase A (CAOS_MANAGE portfolio/ folder) and Phase B (cross-surface drift sync) work from April 2026
- Reframes personal-portfolio management as a data pipeline with canonical sources, mirrors, runbooks, and drift audits

## Files

**Rollings (\`_rollings/\`):**
- \`2026-04-20-01-sync-runbook.md\` — \"The Sync Runbook\"
- \`2026-04-20-02-two-lines.md\` — \"Two Lines\" (on CV bullet compression)

**Post (\`_posts/\`):**
- \`2026-04-20-Four-Surfaces-One-Story.md\` — full architecture narrative

**SVGs (\`images/projects/\`):**
- \`portfolio_sync_flow.svg\` — 5 surfaces, 2 canonical sources, directional arrows
- \`portfolio_drift_matrix.svg\` — 3x4 table of projects × surfaces with ⊕ markers for what was added

## Voice & style conformance

- Rollings: evocative short title, \`======\` echo, SVG + dark reflection box (\`#0d1b2a\` bg, \`#e07830\` accent, \`#5a9ac0\` sub-detail), closing link
- Post: contextual opener, H2 sections, dark callout box, developer → manager → exec framing
- All English per personal-website convention

## Test plan

- [x] Markdown frontmatter valid
- [x] Image references present (new SVGs + existing \`material_tracking.svg\`, \`mining_optimization.svg\`)
- [x] Permalinks follow \`/rollings/YYYY/MM/<slug>/\` and \`/posts/YYYY/MM/<slug>/\`
- [ ] Jekyll build succeeds on GH Pages rebuild

Closes #62