### PR TITLE
Feat: Add live-demo links to 12 portfolio cards

### DIFF
--- a/_portfolio/CEFOP_DinHot.md
+++ b/_portfolio/CEFOP_DinHot.md
@@ -33,6 +33,8 @@ The original implementation ran on lab hardware controlling a physical SLM. The 
 
 ## Live application
 
+▶ **[Live demo — dinhot.fasl-work.com](https://dinhot.fasl-work.com)** — dynamic holographic optical tweezers simulator.
+
 ![Holographic Optical Tweezers — Phase mask computation interface](/images/projects/screenshots/dinhot_frontend.png)
 
 [View on GitHub](https://github.com/fsantibanezleal/CEFOP_DinHot)

--- a/_portfolio/DepthProfiler.md
+++ b/_portfolio/DepthProfiler.md
@@ -63,6 +63,8 @@ This project is the **enabling technology** for granulometry estimation from sur
 
 ## Live application
 
+▶ **[Live demo — profiler.fasl-work.com](https://profiler.fasl-work.com)** — 3D distance profiler and surface reconstruction.
+
 ![3D Distance Profiler — depth map processing and surface analysis](/images/projects/screenshots/depth_profiler_frontend.png)
 
 [View on GitHub](https://github.com/fsantibanezleal/FASL_3D_Distance_Profiler)

--- a/_portfolio/DualPhotography.md
+++ b/_portfolio/DualPhotography.md
@@ -36,6 +36,8 @@ This is not just a matrix transpose. The transport matrix **T** (of size N_camer
 
 ## Live application
 
+▶ **[Live demo — dual.fasl-work.com](https://dual.fasl-work.com)** — dual photography lab — light transport matrices + SVD.
+
 ![Dual Photography Lab — Transport matrix and relighting interface](/images/projects/screenshots/dual_frontend.png)
 
 ### Demo video

--- a/_portfolio/FeelIT2.md
+++ b/_portfolio/FeelIT2.md
@@ -76,6 +76,8 @@ Create new workspaces from external folders with auto-population of models, docu
 
 ## Live application
 
+▶ **[Live demo — feelit.fasl-work.com](https://feelit.fasl-work.com)** — haptic accessibility workbench (4 workspaces + Braille reader).
+
 ![FeelIT 2.0 — Braille Reader workspace](/images/projects/screenshots/feelit2_braille_reader.png)
 
 ![FeelIT 2.0 — 3D Object Explorer](/images/projects/screenshots/feelit2_object_explorer.png)

--- a/_portfolio/GrainSight.md
+++ b/_portfolio/GrainSight.md
@@ -75,6 +75,8 @@ D-values (D10, D25, D50, D75, D80, D90) are extracted from the cumulative PSD cu
 
 ## Live application
 
+▶ **[Live demo — grainsize.fasl-work.com](https://grainsize.fasl-work.com)** — particle size distribution from RGB-D data.
+
 ![GrainSight — particle segmentation, PSD analysis, and grain measurement](/images/projects/screenshots/grainsize_frontend.png)
 
 [View on GitHub](https://github.com/fsantibanezleal/FASL_3D_GrainSize)

--- a/_portfolio/HapticSIM.md
+++ b/_portfolio/HapticSIM.md
@@ -27,6 +27,8 @@ This was my 2008 undergraduate thesis project at Universidad de Concepcion, part
 
 ## Live application
 
+▶ **[Live demo — haptic.fasl-work.com](https://haptic.fasl-work.com)** — 3D haptic simulator — octree collision + spring-damper feedback.
+
 ![3D Haptic Simulation — Octree visualization and force feedback](/images/projects/screenshots/haptic_frontend.png)
 
 [View on GitHub](https://github.com/fsantibanezleal/UDEC_Haptic_SIM)

--- a/_portfolio/IDS_OWP.md
+++ b/_portfolio/IDS_OWP.md
@@ -27,6 +27,8 @@ This work was developed during 2014-2016 at the IDS Group (Information and Decis
 
 ## Live application
 
+▶ **[Live demo — owp.fasl-work.com](https://owp.fasl-work.com)** — optimal sampling visualizer — AdSEMES algorithm in action.
+
 ![Optimal Well Placement — Adaptive sampling visualization](/images/projects/screenshots/owp_frontend.png)
 
 ### Demo video — Adaptive entropy sampling in action

--- a/_portfolio/MinePileVisualizer.md
+++ b/_portfolio/MinePileVisualizer.md
@@ -54,6 +54,8 @@ Belt blocks: (position, massTon, timestampOldest/Newest, qualities)<br/>
 
 ## Live application
 
+▶ **[Live demo — minepile.fasl-work.com](https://minepile.fasl-work.com)** — local-first 3D mining stockpile and circuit explorer.
+
 ![Mine Pile Visualizer — 3D stockpile voxels with categorical quality](/images/projects/screenshots/minepile_3d_stockpile.png)
 
 ![Mine Pile Visualizer — 3D voxels with numeric quality coloring](/images/projects/screenshots/minepile_3d_numeric.png)

--- a/_portfolio/RoboticWriter.md
+++ b/_portfolio/RoboticWriter.md
@@ -49,6 +49,8 @@ The original 2004 lab used MATLAB scripts to command the physical Scorbot III. T
 
 ## Live application
 
+▶ **[Live demo — robotic.fasl-work.com](https://robotic.fasl-work.com)** — interactive Dash simulator running in the browser (simulation mode, no hardware required).
+
 ![Robotic Writer — 3D kinematics simulation and trajectory planning](/images/projects/screenshots/robotic_frontend.png)
 
 ### Demo video — The robot spells words

--- a/_portfolio/SCIAN_CPM.md
+++ b/_portfolio/SCIAN_CPM.md
@@ -52,6 +52,8 @@ Developed during my work at [SCIAN-Lab](http://www.scian.cl/) and the [BNI](http
 
 ## Live application
 
+▶ **[Live demo — cpm.fasl-work.com](https://cpm.fasl-work.com)** — Cellular Potts Model simulator — zebrafish DFC migration.
+
 ![Cellular Potts Model — Interactive web interface](/images/projects/screenshots/cpm_frontend.png)
 
 [View on GitHub](https://github.com/fsantibanezleal/SCIAN_LEO_CPM)

--- a/_portfolio/SCIAN_SpherSIM.md
+++ b/_portfolio/SCIAN_SpherSIM.md
@@ -41,6 +41,8 @@ This project originated at the [Laboratory for Scientific Image Analysis (SCIAN-
 
 ## Live application
 
+▶ **[Live demo — sphersim.fasl-work.com](https://sphersim.fasl-work.com)** — 3D embryo cell migration simulator on a spherical surface.
+
 ![3D Embryo Simulator — Three.js visualization](/images/projects/screenshots/sphersim_frontend.png)
 
 [View on GitHub](https://github.com/fsantibanezleal/SCIAN_EVL_SpherSIM)

--- a/_portfolio/SOFI_QDots.md
+++ b/_portfolio/SOFI_QDots.md
@@ -28,6 +28,8 @@ Related publication: [SOFI of GABAB neurotransmitter receptors in hippocampal ne
 
 ## Live application
 
+▶ **[Live demo — sofi.fasl-work.com](https://sofi.fasl-work.com)** — SOFI super-resolution imaging from quantum dot fluctuations.
+
 ![SOFI — Quantum dot simulation interface](/images/projects/screenshots/sofi_frontend.png)
 
 ![SOFI — Cumulant output visualization](/images/projects/screenshots/sofi_frontend_outputs.png)


### PR DESCRIPTION
Each `_portfolio/` card now opens its 'Live application' section with a direct link to the deployed subdomain on fasl-work.com (or micromundo.app). See commit message for mapping. 12 cards updated, 24 line insertions. Closes gap where visitors had to dig for the deployed URL.