### PR TITLE
Add Auralis/Finn/HSI-topic portfolio + 4 rollings + HSI post

### DIFF
--- a/_portfolio/Auralis.md
+++ b/_portfolio/Auralis.md
@@ -1,0 +1,27 @@
+---
+title: "Auralis — 6D Audio Embedding Visualizer"
+date: 2026-04-24
+excerpt: "Maps any sound onto seven embedding tracks and renders it as a navigable 3D trajectory across a library of 102 curated sounds.<br/><img src='/images/500x300.png'>"
+collection: portfolio
+tags: [audio, embeddings, visualization, threejs, clap, yamnet, fastapi]
+---
+
+**Auralis** turns a sound into a place you can fly through. Each clip is analyzed into a six-dimensional embedding space and rendered as a luminous 3D trajectory, with ten render modes and a curated library of 102 sounds (space, nature, music, human-made).
+
+## The idea
+
+Spectrograms show the signal but not its structure or meaning. Auralis instead projects seven different representations of the same sound into one navigable 6D space — so you can see what each representation "hears" and compare them directly.
+
+<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
+<strong style="color:#e07830;">Seven embedding tracks:</strong><br/>
+Features (interpretable spectral) · PCA / t-SNE / UMAP (projections of MFCC frames) · Tonnetz (harmonic space) · YAMNet (1024-D AudioSet events) · CLAP (512-D audio-text semantics)<br/>
+<span style="color:#5a9ac0;font-size:13px;">All min-max normalized so any feature can drive any axis (X/Y/Z + color + size, time as the implicit 6th). CLAP is precomputed offline so the deployed app stays light.</span>
+</div>
+
+Ten render modes (Comet, Tube, Galaxy, Light-painting, Aurora, …), 102 curated clips with verified per-clip licensing, shareable URL state, bilingual UI.
+
+## Technical stack
+
+Backend: Python, FastAPI; offline pipeline with librosa, scikit-learn/UMAP, TensorFlow/YAMNet, CLAP. Frontend: TypeScript, React, Vite, Three.js (@react-three/fiber), Web Audio API.
+
+▶ Live at [auralis.fasl-work.com](https://auralis.fasl-work.com) · [GitHub](https://github.com/fsantibanezleal/CAOS_6D_Sounds)

--- a/_portfolio/FinnForecasts.md
+++ b/_portfolio/FinnForecasts.md
@@ -1,0 +1,27 @@
+---
+title: "Finn — Personal Finance & Market Forecasting"
+date: 2026-04-30
+excerpt: "Market-analytics app: walk-forward-validated forecasting, a full risk battery, cost-aware backtests, FinBERT news sentiment, and LATAM coverage (IPSA + Chile macro).<br/><img src='/images/500x300.png'>"
+collection: portfolio
+tags: [quant, forecasting, finbert, portfolio, risk, fastapi, plotly]
+---
+
+**Finn** is a personal-finance and market-analytics web app: track instruments, build watchlists and portfolios, run forecasts, and review risk — behind a fast, server-rendered UI. What sets it apart is what it refuses to fake.
+
+## The idea
+
+Most quant demos default to US tickers and frictionless backtests. Finn validates forecasts the way they would actually be traded, charges realistic costs, and covers Latin American markets that mainstream tools ignore.
+
+<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
+<strong style="color:#e07830;">The honest parts:</strong><br/>
+walk-forward cross-validation (train on the past, test on the unseen next window) · transaction costs charged in every backtest<br/>
+<span style="color:#5a9ac0;font-size:13px;">Plus FinBERT finance-aware news sentiment and first-class LATAM coverage — IPSA universe, Chilean macro, Banco Central de Chile.</span>
+</div>
+
+Forecasting (ARIMA/SARIMA, Holt-Winters, GARCH, Random Forest, Gradient Boosting), a full risk battery (Sharpe/Sortino/Calmar, VaR/CVaR, Markowitz / HRP / Black-Litterman / Risk Parity, efficient frontier + Monte Carlo), auth-backed watchlists/portfolios, bilingual ES/EN.
+
+## Technical stack
+
+FastAPI + HTMX + Plotly over a quant stack: pandas, numpy, scipy, statsmodels, scikit-learn, PyPortfolioOpt, arch, hmmlearn.
+
+▶ Live at [finn.fasl-work.com](https://finn.fasl-work.com) · [GitHub](https://github.com/fsantibanezleal/CAOS_WEB_Finn_Forecasts) — *educational demo, not investment advice.*

--- a/_portfolio/HyperspectralTopicModelling.md
+++ b/_portfolio/HyperspectralTopicModelling.md
@@ -1,0 +1,27 @@
+---
+title: "Hyperspectral Mineral Analysis by Topic Modelling"
+date: 2022-09-01
+excerpt: "Treats hyperspectral mineral images as documents and mines them with unsupervised topic models. A design-space sweep over 17 representations finds MI-weighted bands (V20) give the most separable mineral topics. From a 2022 conference paper to a live platform.<br/><img src='/images/projects/hsi_mineral_classification.svg'>"
+collection: portfolio
+tags: [hyperspectral, topic-modelling, lda, unsupervised, mineralogy, representation-learning]
+---
+
+This research line began in 2022 during postdoctoral work — presented as *"Geometallurgical estimation of mineral samples from hyperspectral images and topic modelling"* at the 18th International Conference on Mineral Processing and Geometallurgy — and has since grown into a live interactive platform. It is the **unsupervised counterpart** to the [supervised HSI classification line](/portfolio/HSIMineralClassification/) on the same data.
+
+## The idea
+
+Treat a hyperspectral mineral image as a **document**, its spectral patterns as **vocabulary**, and let unsupervised **topic models** (LDA, ProdLDA, ETM, HDP) discover mineral structure with no labelled training data — which is what makes it transferable across ore bodies and sensors.
+
+<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
+<strong style="color:#e07830;">The result:</strong><br/>
+Across 17 representations (V1–V20) and topic counts Q = 8/16/32, mutual-information-weighted bands (V20) give the most separable mineral topics<br/>
+<span style="color:#5a9ac0;font-size:13px;">V20 wins evaluation axes F-2 and F-7 on Indian Pines (396 labelled cells), lowest topic overlap (Jaccard 0.009 at Q=32), and keeps improving as topic count grows where others plateau. (On F-1 it ties — an honest reading after an internal audit.)</span>
+</div>
+
+A live **Q-extension API** serves topic counts at Q = 8/16/32, with a React/Vite frontend over a FastAPI backend, plus a companion manuscript.
+
+## Technical stack
+
+Python, FastAPI, scikit-learn, gensim, PyTorch; React/Vite frontend.
+
+▶ Live at [lda-hsi.fasl-work.com](https://lda-hsi.fasl-work.com) · [GitHub](https://github.com/fsantibanezleal/CAOS_LDA_HSI)

--- a/_posts/2026-05-31-The-Representation-That-Keeps-Climbing.md
+++ b/_posts/2026-05-31-The-Representation-That-Keeps-Climbing.md
@@ -1,0 +1,46 @@
+---
+title: 'The representation that keeps climbing — topic modelling on hyperspectral minerals'
+date: 2026-05-31
+permalink: /posts/2026/05/representation-that-keeps-climbing/
+tags:
+  - hyperspectral
+  - topic-modelling
+  - representation-learning
+  - mineralogy
+  - research
+---
+
+The representation that keeps climbing
+======
+
+In 2022, during my postdoc, I presented a small idea at the 18th International Conference on Mineral Processing and Geometallurgy: *what if you treat a hyperspectral mineral image like a document?* Each pixel or region is a document, recurring spectral patterns are the vocabulary, and an unsupervised topic model — LDA and its descendants — discovers mineral "topics" with no labelled training data. No lab assays, no ground-truth masks. That property, label-free, is the whole point: it's what lets the method travel to a new ore body or a new sensor without retraining on someone's hand-drawn polygons.
+
+Three years later that idea is a live platform. But the result I actually care about isn't the platform — it's an answer to a question the 2022 paper only gestured at.
+
+## The question nobody asks out loud
+
+A topic model is only as good as what you feed it. Everyone tunes the model — LDA vs ProdLDA vs ETM, how many topics, which priors. Almost nobody systematically asks the upstream question: *which representation of the spectrum should the topic model even see?* Raw bands? A wavelet transform? A learned dictionary? A UMAP embedding? Each one reshapes what "co-occurrence" means before the model ever runs.
+
+So I built the sweep. Seventeen spectral representations — V1 through V20, including continuous-wavelet (CWT-Morlet), sparse-dictionary coding, UMAP embeddings, VQ-VAE codes, graph-Laplacian features, and mutual-information-weighted bands — each scored on an evaluation battery (the "F-axis" set) and extended across topic counts Q = 8, 16, and 32. The benchmark is Indian Pines, the standard labelled hyperspectral scene (396 labelled cells once you clean it up).
+
+## What the sweep found
+
+Most representations plateau. You add topics, and past a point the extra topics just split hairs — the same structure at finer granularity, no real gain in how separable the mineral topics are. That's the expected, slightly disappointing behaviour.
+
+<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
+<strong style="color:#e07830;">V20 — mutual-information-weighted bands — is the one that doesn't plateau.</strong><br/>
+It wins evaluation axes F-2 and F-7 on Indian Pines, with the lowest topic overlap in the whole sweep (Jaccard 0.009 at Q=32)<br/>
+<span style="color:#5a9ac0;font-size:13px;">And it keeps improving as the topic count grows, exactly where the others give up. MI weighting front-loads the bands that actually carry mineral-discriminative signal — so the extra topics have somewhere useful to go instead of fragmenting noise.</span>
+</div>
+
+That's the headline: one representation gets *more* separable precisely where everything else saturates. The interpretation is honest and not over-claimed — mutual-information weighting emphasizes the bands that distinguish minerals, so as you grant the model more topics, it spends them on real structure rather than on slicing noise more finely.
+
+## The honesty beat
+
+There's a detail I want to keep visible, because it's the kind of thing that's easy to bury. An earlier version of this write-up — on the live web app and in the internal notes — claimed a cleaner "triple-axis win." An internal audit caught that on one of the axes (F-1) V20 doesn't win, it **ties**. So the claim is now "wins F-2 and F-7, ties F-1," not "wins everything." A research surface that overclaims is worse than one that's a little behind; the correction is part of the result, not a footnote to hide.
+
+## From a slide to an endpoint
+
+The thing I'm proudest of is mundane: the sweep answers in production. A Q-extension API serves topic counts at Q = 8 / 16 / 32, with a React/Vite frontend over a FastAPI backend, plus a companion manuscript documenting the methodology in full. The 2022 conference slide became a thing you can click.
+
+There's a manager's lesson hiding in here, the same one I keep relearning: knowing *when more model stops helping* is the actual deliverable. Ten representations that saturate are worth less than one that scales. Live at [lda-hsi.fasl-work.com](https://lda-hsi.fasl-work.com).

--- a/_rollings/2026-05-31-01-auralis-live.md
+++ b/_rollings/2026-05-31-01-auralis-live.md
@@ -1,0 +1,23 @@
+---
+title: 'Hearing Sound as a 6D Space'
+date: 2026-05-31
+permalink: /rollings/2026/05/auralis-live/
+tags:
+  - Auralis
+  - Audio
+  - Embeddings
+  - Visualization
+---
+
+Hearing Sound as a 6D Space
+======
+
+Auralis is live — a browser app that turns any sound into a navigable 6D trajectory. Pick from seven embedding tracks and watch the same sound take a completely different shape under each one.
+
+<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
+<strong style="color:#e07830;">Seven tracks:</strong><br/>
+Features · PCA · t-SNE · UMAP · Tonnetz (harmonic space) · YAMNet (AudioSet events) · CLAP (audio-text semantics)<br/>
+<span style="color:#5a9ac0;font-size:13px;">CLAP places semantically similar sounds together even when their spectra differ — and it's precomputed offline, so the deployed app stays light.</span>
+</div>
+
+Ten render modes, 102 curated clips (NASA space audio and a NOAA underwater set included), shareable URLs. Live at [auralis.fasl-work.com](https://auralis.fasl-work.com).

--- a/_rollings/2026-05-31-02-finn-live.md
+++ b/_rollings/2026-05-31-02-finn-live.md
@@ -1,0 +1,23 @@
+---
+title: "A Market Demo That Doesn't Fake Its Backtests"
+date: 2026-05-31
+permalink: /rollings/2026/05/finn-live/
+tags:
+  - Finn
+  - Quant
+  - Forecasting
+  - NLP
+---
+
+A Market Demo That Doesn't Fake Its Backtests
+======
+
+Finn Forecasts is live — forecasting, portfolios, and risk behind a fast server-rendered UI. The parts I care about are the honest ones.
+
+<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
+<strong style="color:#e07830;">Rigor over polish:</strong><br/>
+walk-forward cross-validation (no future leakage) · transaction costs charged in the backtester<br/>
+<span style="color:#5a9ac0;font-size:13px;">Plus FinBERT for finance-aware news sentiment, and first-class LATAM coverage — IPSA universe + Chilean macro + Banco Central de Chile.</span>
+</div>
+
+A general sentiment model fumbles "missed guidance" vs "raised guidance"; FinBERT doesn't. And rather than defaulting to US tickers, Finn covers the markets I actually live in. Live at [finn.fasl-work.com](https://finn.fasl-work.com) — educational demo, not investment advice.

--- a/_rollings/2026-05-31-03-hsi-topic-v20.md
+++ b/_rollings/2026-05-31-03-hsi-topic-v20.md
@@ -1,0 +1,23 @@
+---
+title: 'The Hyperspectral Representation That Keeps Improving'
+date: 2026-05-31
+permalink: /rollings/2026/05/hsi-topic-v20/
+tags:
+  - Hyperspectral
+  - Topic-Modelling
+  - Representation-Learning
+  - Research
+---
+
+The Hyperspectral Representation That Keeps Improving
+======
+
+The topic-modelling line I started in 2022 — a Procemin/MinProGeo conference paper, the unsupervised counterpart to the [supervised HSI work](/rollings/2025/11/Post-2025-11-10-01/) — now has a clean result.
+
+<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
+<strong style="color:#e07830;">V20 — mutual-information-weighted bands:</strong><br/>
+wins evaluation axes F-2 and F-7 on Indian Pines, lowest topic overlap (Jaccard 0.009 at Q=32)<br/>
+<span style="color:#5a9ac0;font-size:13px;">Across 17 representations and three topic counts (Q = 8/16/32), V20 keeps improving as the topic count grows — where most representations plateau. MI weighting front-loads the bands that actually carry mineral-discriminative signal. (On F-1 it ties, not wins — an honest reading after an internal audit.)</span>
+</div>
+
+It's live, not just a slide — a Q-extension API now serves topic counts at Q = 8/16/32 at [lda-hsi.fasl-work.com](https://lda-hsi.fasl-work.com).

--- a/_rollings/2026-05-31-04-underrisk-demo.md
+++ b/_rollings/2026-05-31-04-underrisk-demo.md
@@ -1,0 +1,23 @@
+---
+title: 'An Operator Dashboard for Explainable Risk'
+date: 2026-05-31
+permalink: /rollings/2026/05/underrisk-demo/
+tags:
+  - Geotechnical
+  - Mining
+  - Visualization
+  - SHAP
+---
+
+An Operator Dashboard for Explainable Risk
+======
+
+UnderMine Risk is a demo of the operator-facing last mile for explainable geotechnical risk: weekly per-extraction-point risk on a deck.gl mine map.
+
+<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
+<strong style="color:#e07830;">Two design choices I'd defend:</strong><br/>
+aggregation rolls up by riskMax + maxDelta, never the mean — so an escalating point can't hide in an average · every view exports to a printable monthly report<br/>
+<span style="color:#5a9ac0;font-size:13px;">SHAP history per point explains why the risk moved week over week. Runs on fully synthetic data behind authentication — the engineering of an operator UI, not a production safety system.</span>
+</div>
+
+Next.js 16 + React 19 over a weekly Python pipeline. Demo (auth-gated) at [underrisk.fasl-work.com](https://underrisk.fasl-work.com).


### PR DESCRIPTION
Personal site content: 3 new _portfolio entries (Auralis, Finn, Hyperspectral Topic Modelling 2022-origin), 4 rollings (overdue feed since 2026-04-20), and one long-form post on the HSI topic-modelling V20 result (with the honest F-1 tie correction). YAML front-matter validated.