### PR TITLE
Rewrite Auralis + Finn portfolio entries (business->technical->KPI flow)

### DIFF
--- a/_portfolio/Auralis.md
+++ b/_portfolio/Auralis.md
@@ -1,27 +1,62 @@
 ---
 title: "Auralis — 6D Audio Embedding Visualizer"
 date: 2026-04-24
-excerpt: "Maps any sound onto seven embedding tracks and renders it as a navigable 3D trajectory across a library of 102 curated sounds.<br/><img src='/images/500x300.png'>"
+excerpt: "Turns any sound into a navigable six-dimensional universe — seven embedding tracks, ten render modes, 102 curated clips — making abstract audio-ML representations tangible.<br/><img src='/images/projects/auralis_embedding_space.svg'>"
 collection: portfolio
 tags: [audio, embeddings, visualization, threejs, clap, yamnet, fastapi]
 ---
 
-**Auralis** turns a sound into a place you can fly through. Each clip is analyzed into a six-dimensional embedding space and rendered as a luminous 3D trajectory, with ten render modes and a curated library of 102 sounds (space, nature, music, human-made).
+A **browser-based audio visualization platform** that maps any sound onto seven different machine-learning embedding spaces and renders it as a luminous, navigable 3D trajectory. Auralis exists to answer a question that is normally invisible: *how does a model actually "hear" a sound, and how do different representations disagree about it?*
 
-## The idea
+## Business impact
 
-Spectrograms show the signal but not its structure or meaning. Auralis instead projects seven different representations of the same sound into one navigable 6D space — so you can see what each representation "hears" and compare them directly.
+Audio embeddings quietly power search, recommendation, classification, and generative audio — but they are abstract high-dimensional vectors that no stakeholder can inspect. Auralis turns that black box into something you can see, compare, and reason about. By projecting seven representations of the same clip into one shared 6D space, it becomes both an **analytical instrument** (which representation separates these sounds? where does a model confuse them?) and a **communication tool** (showing a non-specialist what "semantic audio similarity" means, live, in a browser tab).
 
-<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
-<strong style="color:#e07830;">Seven embedding tracks:</strong><br/>
-Features (interpretable spectral) · PCA / t-SNE / UMAP (projections of MFCC frames) · Tonnetz (harmonic space) · YAMNet (1024-D AudioSet events) · CLAP (512-D audio-text semantics)<br/>
-<span style="color:#5a9ac0;font-size:13px;">All min-max normalized so any feature can drive any axis (X/Y/Z + color + size, time as the implicit 6th). CLAP is precomputed offline so the deployed app stays light.</span>
-</div>
+| Metric | Result |
+|--------|--------|
+| Embedding tracks | 7 (Features, PCA, t-SNE, UMAP, Tonnetz, YAMNet, CLAP) |
+| Render modes | 10 (Comet, Tube, Galaxy, Aurora, Light-painting, …) |
+| Curated library | 102 licensed clips (space, nature, music, human-made) |
+| Deployment | Live, browser-only; heavy CLAP runtime precomputed offline |
 
-Ten render modes (Comet, Tube, Galaxy, Light-painting, Aurora, …), 102 curated clips with verified per-clip licensing, shareable URL state, bilingual UI.
+## Strategic context
 
-## Technical stack
+Most audio tools stop at the spectrogram — useful to an engineer, opaque to everyone else — and the embedding spaces inside modern audio models are never shown at all. Auralis closes that gap. It is the difference between *telling* someone that CLAP groups "the sound of rain" near actual rain and *showing* them the two clips landing in the same region of space while their raw spectra look nothing alike. As a portfolio piece it demonstrates fluency across the full stack of audio intelligence — classical DSP, deep audio models, dimensionality reduction, and real-time 3D rendering — fused into one coherent product rather than a notebook.
 
-Backend: Python, FastAPI; offline pipeline with librosa, scikit-learn/UMAP, TensorFlow/YAMNet, CLAP. Frontend: TypeScript, React, Vite, Three.js (@react-three/fiber), Web Audio API.
+![6D embedding architecture](/images/projects/auralis_embedding_space.svg)
 
-▶ Live at [auralis.fasl-work.com](https://auralis.fasl-work.com) · [GitHub](https://github.com/fsantibanezleal/CAOS_6D_Sounds)
+## Key Performance Indicators — what it surfaces
+
+The value is in making representation differences legible and comparable, not in a single accuracy number.
+
+| KPI | Baseline (typical audio tooling) | With Auralis | Impact |
+|-----|----------------------------------|--------------|--------|
+| Representation visibility | One spectrogram view | 7 embedding tracks, switchable | Compare what each model "hears" of the same sound |
+| Exploration | Flat 2D waveform / spectrogram | Navigable 6D trajectory (XYZ + color + size + time) | Sound becomes a space, not a signal |
+| Semantic grouping | Not exposed | CLAP audio-text track clusters by meaning | Semantically similar sounds group even when spectra differ |
+| Accessibility of ML | Notebook + NumPy arrays | Interactive browser app with shareable URLs | A non-specialist can explore embeddings directly |
+| Reproducibility | Ad-hoc per analysis | Persisted per-track projection models | Every clip maps into the same, comparable space |
+
+## The challenge
+
+A sound is a time series; an embedding is a high-dimensional vector per frame; a screen is two-dimensional. Bridging all three in real time is the core problem. Each clip is analyzed into **seven embedding tracks** — interpretable spectral Features, PCA/t-SNE/UMAP projections of MFCC frames (one linear, two manifold methods), the Tonnetz harmonic space, YAMNet's 1024-D AudioSet event embeddings, and CLAP's 512-D contrastive audio-text embeddings — and every track is min-max normalized to a common 6D so that *any* feature can drive *any* visual axis. The CLAP model is heavy (a full torch/transformers stack), so its embeddings are computed offline and the production app ships only the precomputed vectors, keeping the deployed surface light enough to run entirely in the browser.
+
+## System architecture
+
+1. **Offline analysis pipeline**: librosa extracts spectral features and MFCCs per frame; scikit-learn and UMAP fit the corpus-wide PCA / t-SNE / UMAP projections; TensorFlow/YAMNet and CLAP produce the deep embeddings. Per-track projection models are persisted so every clip maps into a consistent, comparable space.
+2. **6D → visual mapping**: spatial position (X, Y, Z) plus color (4th dimension), point size (5th), and time as the implicit 6th axis — past frames fade into a trail, so the *shape* of the trajectory itself encodes the structure of the sound.
+3. **Real-time renderer**: a React + Three.js (`@react-three/fiber`) frontend draws the trajectory in ten render modes, synchronized to Web Audio API playback; full panel state (clip, track, axis mapping, render mode) round-trips through the URL hash for shareable views.
+4. **Serving layer**: a FastAPI backend serves the precomputed per-clip JSON and the audio assets; the SPA is static and CDN-friendly.
+
+## Technology stack
+
+- **Backend / pipeline**: Python, FastAPI, librosa, scikit-learn, UMAP, TensorFlow (YAMNet), CLAP (offline)
+- **Frontend**: TypeScript, React, Vite, Three.js / @react-three/fiber, Zustand, Web Audio API
+- **Representations**: spectral DSP, MFCC, Tonnetz, PCA / t-SNE / UMAP, deep audio embeddings (YAMNet, CLAP)
+- **Deployment**: systemd + nginx on a Hetzner VPS; CLAP embeddings precomputed so production stays light
+
+## Live application
+
+▶ **[Live demo — auralis.fasl-work.com](https://auralis.fasl-work.com)** — pick a clip, choose an embedding track, and fly through its 6D trajectory.
+
+[View on GitHub](https://github.com/fsantibanezleal/CAOS_6D_Sounds)

--- a/_portfolio/FinnForecasts.md
+++ b/_portfolio/FinnForecasts.md
@@ -1,27 +1,67 @@
 ---
 title: "Finn — Personal Finance & Market Forecasting"
 date: 2026-04-30
-excerpt: "Market-analytics app: walk-forward-validated forecasting, a full risk battery, cost-aware backtests, FinBERT news sentiment, and LATAM coverage (IPSA + Chile macro).<br/><img src='/images/500x300.png'>"
+excerpt: "Full-stack market-analytics platform: forecasting with walk-forward validation, a full risk and portfolio battery, cost-aware backtesting, FinBERT news sentiment, and LATAM market coverage.<br/><img src='/images/projects/finn_architecture.svg'>"
 collection: portfolio
 tags: [quant, forecasting, finbert, portfolio, risk, fastapi, plotly]
 ---
 
-**Finn** is a personal-finance and market-analytics web app: track instruments, build watchlists and portfolios, run forecasts, and review risk — behind a fast, server-rendered UI. What sets it apart is what it refuses to fake.
+A **full-stack personal-finance and market-analytics platform**: track instruments, build watchlists and portfolios, run statistical and ML forecasts, review risk, and read finance-aware news sentiment — behind a fast, server-rendered UI. What separates Finn from the average finance dashboard is what it refuses to fake.
 
-## The idea
+## Business impact
 
-Most quant demos default to US tickers and frictionless backtests. Finn validates forecasts the way they would actually be traded, charges realistic costs, and covers Latin American markets that mainstream tools ignore.
+Finance tooling tends to split into two camps: polished dashboards with shallow analytics, or powerful quant libraries with no usable interface. Neither serves someone who wants *real* forecasting and risk analysis, *honest* backtesting, and coverage of Latin American markets — which mainstream tools largely ignore — without standing up a research environment from scratch. Finn packages a research-grade analytics stack behind a clean web app, and its credibility comes from two deliberate engineering choices most demos skip: forecasts validated the way they would actually be traded, and backtests that charge the costs of trading.
 
-<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
-<strong style="color:#e07830;">The honest parts:</strong><br/>
-walk-forward cross-validation (train on the past, test on the unseen next window) · transaction costs charged in every backtest<br/>
-<span style="color:#5a9ac0;font-size:13px;">Plus FinBERT finance-aware news sentiment and first-class LATAM coverage — IPSA universe, Chilean macro, Banco Central de Chile.</span>
-</div>
+| Metric | Result |
+|--------|--------|
+| Forecasting models | ARIMA/SARIMA, Holt-Winters, GARCH, Random Forest, Gradient Boosting + HMM regimes |
+| Validation | Walk-forward cross-validation (no future leakage) |
+| Backtesting | Transaction-cost-aware (`cost_bp`) — net, not gross, equity |
+| Market coverage | US + **LATAM** (IPSA universe, Chilean macro, Banco Central de Chile) |
+| News sentiment | FinBERT (finance-tuned), not a general sentiment model |
 
-Forecasting (ARIMA/SARIMA, Holt-Winters, GARCH, Random Forest, Gradient Boosting), a full risk battery (Sharpe/Sortino/Calmar, VaR/CVaR, Markowitz / HRP / Black-Litterman / Risk Parity, efficient frontier + Monte Carlo), auth-backed watchlists/portfolios, bilingual ES/EN.
+## Strategic context
 
-## Technical stack
+A quant demo that defaults to US tickers and frictionless backtests looks impressive and quietly misleads — strategies that only worked because they traded for free, and accuracy numbers inflated by future leakage. Finn is built to be the opposite: a tool you could hand to an analyst because it is honest about validation and costs, and relevant because it covers the markets it was built in. As a portfolio piece it demonstrates depth across time-series econometrics, portfolio optimization, NLP, and full-stack delivery — and the judgment to know which guarantees actually make a market tool trustworthy.
 
-FastAPI + HTMX + Plotly over a quant stack: pandas, numpy, scipy, statsmodels, scikit-learn, PyPortfolioOpt, arch, hmmlearn.
+![Architecture and integrity guarantees](/images/projects/finn_architecture.svg)
 
-▶ Live at [finn.fasl-work.com](https://finn.fasl-work.com) · [GitHub](https://github.com/fsantibanezleal/CAOS_WEB_Finn_Forecasts) — *educational demo, not investment advice.*
+## Key Performance Indicators — what makes it trustworthy
+
+The headline isn't a return number — it's the integrity of the analytics behind every screen.
+
+| KPI | Baseline (typical demo) | With Finn | Impact |
+|-----|-------------------------|-----------|--------|
+| Forecast validation | In-sample fit (future leaks in) | Walk-forward cross-validation | Reported error is genuinely out-of-sample |
+| Backtest realism | Zero-cost trades | Transaction costs charged (`cost_bp`) | Strategies must survive contact with reality |
+| News sentiment | General-purpose model | FinBERT finance-tuned | "missed guidance" vs "raised guidance" read correctly |
+| Market coverage | US tickers only | IPSA + Chile macro + BCCh | Usable for Latin American markets |
+| State | Stateless toy | Auth-backed watchlists & portfolios | Persisted, multi-instrument workflows |
+
+## The challenge
+
+Bringing research-grade quantitative finance to a responsive web app means three problems at once: a heavy numerical stack (pandas, NumPy, SciPy, statsmodels, PyPortfolioOpt, arch, hmmlearn) that must answer fast; methodological rigor that resists the usual demo shortcuts; and a UI that stays snappy while rendering econometric charts. Finn solves the speed/weight tension with a server-rendered HTMX architecture and cached computation, and solves the rigor problem head-on: **walk-forward cross-validation** trains on the past and tests on the unseen next window (rolling forward, never leaking the future into the fit), and the backtester charges **transaction costs**, the fastest way to kill a strategy that only looked good because it traded for free.
+
+## System architecture
+
+1. **Data layer**: market OHLCV via yfinance, fundamentals, an 8-source financial news RSS aggregator, and macro series from FRED — plus a first-class **LATAM** extension (IPSA universe, Chilean macro series, a Banco Central de Chile stub).
+2. **Analytics core (FastAPI)**: a quant stack exposed as cached endpoints — forecasting (ARIMA/SARIMA, Holt-Winters, GARCH, RF, Gradient Boosting; HMM regime detection), a full risk battery (volatility, Sharpe/Sortino/Calmar, VaR/CVaR), and portfolio optimization (Markowitz, HRP, Black-Litterman, Risk Parity, efficient frontier + Monte Carlo).
+3. **Sentiment**: FinBERT scores headlines via the HF Inference API and folds finance-aware sentiment into the view.
+4. **Backtesting**: Buy & Hold, periodic rebalancing, momentum, mean-reversion and pairs strategies — each evaluated with transaction costs and the full risk metric suite, reporting net equity and drawdown.
+5. **Frontend & persistence**: Jinja2 + HTMX server rendering with interactive Plotly charts (fan charts, drawdown, fundamentals bubbles, regime shading); auth-backed watchlists and portfolios persist per user; bilingual ES/EN.
+
+## Technology stack
+
+- **Backend**: FastAPI, Pydantic v2, Uvicorn; SQLAlchemy persistence + auth
+- **Quant**: pandas, NumPy, SciPy, statsmodels, scikit-learn, PyPortfolioOpt, arch, hmmlearn
+- **Data**: yfinance, FRED / pandas-datareader, feedparser; FinBERT via HF Inference API
+- **Frontend**: Jinja2, HTMX, Plotly.js, custom dark-theme CSS
+- **Deployment**: systemd + nginx on a Hetzner VPS
+
+## Live application
+
+▶ **[Live demo — finn.fasl-work.com](https://finn.fasl-work.com)** — forecasting, risk, portfolios, and news sentiment in one app.
+
+[View on GitHub](https://github.com/fsantibanezleal/CAOS_WEB_Finn_Forecasts)
+
+*Educational demonstration — not financial advice, investment recommendation, or an offer to buy or sell.*


### PR DESCRIPTION
Replace the thin Auralis/Finn portfolio stubs with full house-style entries: Business impact + metric table, Strategic context + diagram, KPI table, The challenge, numbered System architecture, Technology stack, Live application. Excerpts point at the SVG diagrams already on master.