### PR TITLE
Deepen the four 2026-05-31 rollings

### DIFF
--- a/_rollings/2026-05-31-01-auralis-live.md
+++ b/_rollings/2026-05-31-01-auralis-live.md
@@ -12,12 +12,20 @@ tags:
 Hearing Sound as a 6D Space
 ======
 
-Auralis is live — a browser app that turns any sound into a navigable 6D trajectory. Pick from seven embedding tracks and watch the same sound take a completely different shape under each one.
+I have spent a lot of my career looking at high-dimensional data and wishing I could just *see* it. Audio embeddings are the worst offenders: a model listens to a sound and emits a vector of hundreds of numbers that supposedly captures what the sound "is", and there is no honest way to inspect that vector. You trust it, or you don't. Auralis is my attempt to stop trusting blindly — it turns any sound into a luminous trajectory you can fly through in three dimensions, and it's now live in the browser.
+
+The core idea is that a sound doesn't have *one* representation, it has many, and they disagree in interesting ways. So Auralis computes seven of them per clip and lets you switch between them live. Each one is a different answer to the question "where does this sound sit?"
+
+![Auralis — seven embedding tracks rendered as a 6D trajectory](/images/projects/auralis_embedding_space.svg)
 
 <div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
-<strong style="color:#e07830;">Seven tracks:</strong><br/>
-Features · PCA · t-SNE · UMAP · Tonnetz (harmonic space) · YAMNet (AudioSet events) · CLAP (audio-text semantics)<br/>
-<span style="color:#5a9ac0;font-size:13px;">CLAP places semantically similar sounds together even when their spectra differ — and it's precomputed offline, so the deployed app stays light.</span>
+<strong style="color:#e07830;">Seven embedding tracks, one shared 6D space:</strong><br/>
+Features (interpretable spectral) · PCA · t-SNE · UMAP (three projections of MFCC frames) · Tonnetz (harmonic) · YAMNet (1024-D AudioSet events) · CLAP (512-D audio-text semantics)<br/>
+<span style="color:#5a9ac0;font-size:13px;">All min-max normalized so any feature can drive any axis: position X/Y/Z, color (4D), point size (5D), and time as the implicit 6th — past frames fade into a trail, so the <em>shape</em> of the path is the structure of the sound.</span>
 </div>
 
-Ten render modes, 102 curated clips (NASA space audio and a NOAA underwater set included), shareable URLs. Live at [auralis.fasl-work.com](https://auralis.fasl-work.com).
+The track I keep coming back to is CLAP, a contrastive language-audio model. Where the spectral features describe *how* a sound is built and YAMNet labels *what kind of event* it is, CLAP captures something closer to *meaning* — it was trained to line up "the sound of rain" with actual rain. Pick that track and the NOAA underwater recordings drift away from the spacecraft telemetry in a way the raw spectra never manage, because two clips that *mean* similar things land near each other even when their frequency content looks nothing alike.
+
+I want to be precise about what's actually deployed, because it would be easy to oversell this. CLAP can in principle do text-to-audio search — type a phrase, get the nearest sounds — and that part is **not** live: the model runtime is a heavy torch/transformers stack and I parked the text endpoint until I decide where to host it. What ships is the embedding *track*: all 102 clips already have their CLAP coordinates computed offline and PCA-projected, so the visualization is real and the deployed app stays light enough to run entirely in a browser tab.
+
+The library is half the fun — 102 curated, individually-licensed clips spanning NASA space audio (Perseverance, the Voyager Golden Record, Cassini, Apollo), a NOAA underwater set, birds, machines, music. Ten render modes (Comet, Tube, Galaxy, Aurora, Light-painting…), and every view round-trips through the URL so you can paste a link and someone sees the exact same trajectory. Live at [auralis.fasl-work.com](https://auralis.fasl-work.com) · [GitHub](https://github.com/fsantibanezleal/CAOS_6D_Sounds).

--- a/_rollings/2026-05-31-02-finn-live.md
+++ b/_rollings/2026-05-31-02-finn-live.md
@@ -12,12 +12,20 @@ tags:
 A Market Demo That Doesn't Fake Its Backtests
 ======
 
-Finn Forecasts is live — forecasting, portfolios, and risk behind a fast server-rendered UI. The parts I care about are the honest ones.
+Every quant demo I have ever clicked through does two dishonest things, and they are so common that people stopped noticing. It backtests with zero transaction costs, so every strategy looks profitable. And it evaluates its forecasts in-sample, so the model has secretly already seen the future it claims to predict. The charts look spectacular and mean almost nothing. Finn is the market-analytics app I built to be the opposite of that — and it's now live.
+
+The bones are what you'd expect: track instruments, build watchlists and portfolios, run forecasts, review a full risk battery, all behind a fast server-rendered UI. The part I actually care about is the two places where most demos quietly lie, and where Finn refuses to.
+
+![Finn — architecture and the rigor that separates a demo from a trap](/images/projects/finn_architecture.svg)
 
 <div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
-<strong style="color:#e07830;">Rigor over polish:</strong><br/>
-walk-forward cross-validation (no future leakage) · transaction costs charged in the backtester<br/>
-<span style="color:#5a9ac0;font-size:13px;">Plus FinBERT for finance-aware news sentiment, and first-class LATAM coverage — IPSA universe + Chilean macro + Banco Central de Chile.</span>
+<strong style="color:#e07830;">The two honest parts:</strong><br/>
+Walk-forward cross-validation — train on the past, test on the unseen next window, roll forward. No future leaks into the fit.<br/>
+<span style="color:#5a9ac0;font-size:13px;">Cost-aware backtesting — every strategy is charged transaction costs (cost_bp), so the equity curve you see is net, not the fantasy gross curve. The gap between the two is the cost of trading, and Finn shows it instead of hiding it.</span>
 </div>
 
-A general sentiment model fumbles "missed guidance" vs "raised guidance"; FinBERT doesn't. And rather than defaulting to US tickers, Finn covers the markets I actually live in. Live at [finn.fasl-work.com](https://finn.fasl-work.com) — educational demo, not investment advice.
+The forecasting side spans the classical and the learned — ARIMA/SARIMA, Holt-Winters, GARCH for volatility, Random Forest and Gradient Boosting, plus HMM regime detection — but the model zoo is not the point. The point is that walk-forward validation reports an error you could actually have achieved trading it. A strategy that only looked good because it traded for free dies the moment `cost_bp` is non-zero, and that death is a feature: it's the demo telling you the truth.
+
+News sentiment gets the same treatment. A general-purpose sentiment model fumbles financial text — "missed guidance" and "raised guidance" sit next to each other in ordinary vocabulary space but mean opposite things to a price. Finn scores headlines with FinBERT, fine-tuned on financial language, via the HF Inference API, so the sentiment signal is finance-aware rather than naive.
+
+And it covers the market I actually live in. Mainstream tools default to AAPL and SPY and forget that exchanges exist south of Miami; Finn adds the IPSA universe, Chilean macro series, and a Banco Central de Chile stub as first-class data, alongside US coverage. Risk analytics (Sharpe/Sortino/Calmar, VaR/CVaR, Markowitz / HRP / Black-Litterman / Risk Parity, efficient frontier + Monte Carlo) and Plotly visualizations round it out, with auth-backed watchlists and portfolios that persist per user. Live at [finn.fasl-work.com](https://finn.fasl-work.com) · [GitHub](https://github.com/fsantibanezleal/CAOS_WEB_Finn_Forecasts). *Educational demo — not investment advice.*

--- a/_rollings/2026-05-31-03-hsi-topic-v20.md
+++ b/_rollings/2026-05-31-03-hsi-topic-v20.md
@@ -12,12 +12,20 @@ tags:
 The Hyperspectral Representation That Keeps Improving
 ======
 
-The topic-modelling line I started in 2022 — a Procemin/MinProGeo conference paper, the unsupervised counterpart to the [supervised HSI work](/rollings/2025/11/Post-2025-11-10-01/) — now has a clean result.
+Back in 2022, during my postdoc, I presented a small idea at the 18th International Conference on Mineral Processing and Geometallurgy: treat a hyperspectral mineral image like a *document*. Each pixel or region is a document, the recurring spectral patterns are its vocabulary, and an unsupervised topic model — LDA and its descendants — discovers mineral "topics" with no labelled training data at all. That label-free property is the whole point: it's what lets the method travel to a new ore body or a new sensor without someone first hand-drawing ground-truth masks. Three years later that idea is a live platform, and it finally has a clean result worth writing down.
+
+The question the original paper only gestured at is the one I think actually matters. Everyone tunes the *model* — LDA versus ProdLDA versus ETM, how many topics, which priors. Almost nobody asks the upstream question: which *representation* of the spectrum should the topic model even see? Raw bands? A wavelet transform? A learned dictionary? A UMAP embedding? Each one reshapes what "co-occurrence" means before the model runs a single iteration.
+
+So I built the sweep — seventeen spectral representations (V1 through V20), each scored on an evaluation battery and extended across topic counts Q = 8, 16, 32, on the Indian Pines benchmark (396 labelled cells).
 
 <div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
-<strong style="color:#e07830;">V20 — mutual-information-weighted bands:</strong><br/>
-wins evaluation axes F-2 and F-7 on Indian Pines, lowest topic overlap (Jaccard 0.009 at Q=32)<br/>
-<span style="color:#5a9ac0;font-size:13px;">Across 17 representations and three topic counts (Q = 8/16/32), V20 keeps improving as the topic count grows — where most representations plateau. MI weighting front-loads the bands that actually carry mineral-discriminative signal. (On F-1 it ties, not wins — an honest reading after an internal audit.)</span>
+<strong style="color:#e07830;">V20 — mutual-information-weighted bands — is the one that doesn't plateau.</strong><br/>
+It wins evaluation axes F-2 and F-7 on Indian Pines, with the lowest topic overlap in the whole sweep (Jaccard 0.009 at Q=32).<br/>
+<span style="color:#5a9ac0;font-size:13px;">And it keeps improving as the topic count grows, exactly where the others give up — V12 peaks at Q=16, V3 saturates at Q=8. MI weighting front-loads the bands that carry mineral-discriminative signal, so the extra topics have somewhere useful to go instead of fragmenting noise.</span>
 </div>
 
-It's live, not just a slide — a Q-extension API now serves topic counts at Q = 8/16/32 at [lda-hsi.fasl-work.com](https://lda-hsi.fasl-work.com).
+Most representations plateau, which is the boring expected behaviour: past some point, extra topics just split hairs at finer granularity with no real gain in separability. V20 doesn't do that. It gets *more* separable precisely where everything else saturates, and that's the genuinely interesting finding — not "topic models work on spectra" (we knew that) but "the representation you feed them decides whether more capacity helps or just fragments noise."
+
+One honesty note, because it's the kind of thing that's easy to bury. An earlier version of this write-up — on the live web app and in my own notes — claimed a cleaner "triple-axis win." An internal audit caught that on one of the axes, F-1, V20 doesn't win, it **ties**. So the claim is now "wins F-2 and F-7, ties F-1," not "wins everything." A research surface that overclaims is worse than one that's a little behind, and the correction belongs in the open, not in a footnote.
+
+The part I'm quietly proudest of is the most mundane: the sweep answers in production. A Q-extension API now serves topic counts at Q = 8 / 16 / 32 behind a React/Vite frontend on a FastAPI backend, with a companion manuscript documenting the methodology. The 2022 conference slide is an endpoint you can click. Live at [lda-hsi.fasl-work.com](https://lda-hsi.fasl-work.com).

--- a/_rollings/2026-05-31-04-underrisk-demo.md
+++ b/_rollings/2026-05-31-04-underrisk-demo.md
@@ -12,12 +12,18 @@ tags:
 An Operator Dashboard for Explainable Risk
 ======
 
-UnderMine Risk is a demo of the operator-facing last mile for explainable geotechnical risk: weekly per-extraction-point risk on a deck.gl mine map.
+Every machine-learning safety project I have worked on in mining hits the same wall, and it has nothing to do with the model. You build a weekly risk predictor — rockburst and slope-instability risk from seismic and geotechnical features — you validate it, you even add SHAP so it's explainable. And then it sits in a notebook, producing a number per extraction point per week that no shift supervisor will ever read. The model is fine. The last mile is missing. UnderMine Risk is a demo of that last mile.
+
+It puts the risk on a map. Every extraction point (PEX) gets its predicted weekly risk rendered on a deck.gl top-down view of the mine, across multiple areas, with the SHAP history behind each point so an operator can see not just *that* a zone is escalating but *why*, week over week. The model output stops being a column in a CSV and becomes something you can point at in a meeting.
+
+![UnderMine Risk — per-PEX weekly risk on an interactive mine map](/images/projects/geotechnical_risk.svg)
 
 <div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
-<strong style="color:#e07830;">Two design choices I'd defend:</strong><br/>
-aggregation rolls up by riskMax + maxDelta, never the mean — so an escalating point can't hide in an average · every view exports to a printable monthly report<br/>
-<span style="color:#5a9ac0;font-size:13px;">SHAP history per point explains why the risk moved week over week. Runs on fully synthetic data behind authentication — the engineering of an operator UI, not a production safety system.</span>
+<strong style="color:#e07830;">Two design choices I would defend in any review:</strong><br/>
+Aggregation layers (street / sub-sector / cluster) roll up by riskMax + maxDelta — never the mean.<br/>
+<span style="color:#5a9ac0;font-size:13px;">In a safety context the whole reason to summarize is the one escalating point, and a mean is exactly the summary that buries it. Second: every view exports to a print-optimized monthly report, because the people who sign off on mine safety still sign on paper.</span>
 </div>
 
-Next.js 16 + React 19 over a weekly Python pipeline. Demo (auth-gated) at [underrisk.fasl-work.com](https://underrisk.fasl-work.com).
+The aggregation decision is the one I care about most. It is tempting to roll a sector up by its average risk, and it is exactly wrong: averaging is how a single dangerous point disappears into a calm neighborhood. So the roll-ups carry the maximum and the biggest week-over-week jump instead — the summary is designed to surface the outlier, not smooth it away. The actionables engine then turns an elevated point into concrete responses by lever, and the whole thing exports to a monthly PDF for the people whose workflow is still paper.
+
+I need to be honest about what this is and isn't. The live app runs on **fully synthetic data** and is behind authentication — it is the engineering of an operator interface for explainable risk (deck.gl, aggregation logic, actionables, audit-ready reporting), not a claim that any production mine is running on it. It's a Next.js 16 + React 19 front end over a weekly Python pipeline, and it was industrialized this year out of a real geotechnical-risk modelling effort I mentored. Demo (auth-gated) at [underrisk.fasl-work.com](https://underrisk.fasl-work.com).


### PR DESCRIPTION
Expand the Auralis/Finn/HSI/UnderMine rollings from ~135-word stubs to full house-weight entries (~350-550 words) with narrative arc, image, technical-depth block, honesty beat, reflective close.