### PR TITLE
feat: SimLab + RotorVitals cards + backfill SVGs on all entries

### DIFF
--- a/_portfolio/Circuita.md
+++ b/_portfolio/Circuita.md
@@ -1,7 +1,7 @@
 ---
 title: "Circuita — Stochastic Mineral-Tracking Engine & Console"
 date: 2026-06-08
-excerpt: "A private analysis console built on a stochastic cellular-automaton engine that tracks material through a processing circuit, with a self-contained bilingual report export."
+excerpt: "A private analysis console built on a stochastic cellular-automaton engine that tracks material through a processing circuit, with a self-contained bilingual report export.<br/><img src='/images/projects/circuita_architecture.svg'>"
 collection: portfolio
 tags: [mining, cellular-automaton, simulation, reporting, private]
 ---
@@ -9,6 +9,8 @@ tags: [mining, cellular-automaton, simulation, reporting, private]
 > **Private product.** This is proprietary work; the deployment is private. This page describes the architecture and intent without exposing internal data or logic.
 
 **Circuita** drives a **stochastic cellular-automaton** engine that simulates how material moves, mixes, and lags through a processing circuit — the behavior a static mass balance misses. The result renders in an operator-grade console: per-pile **fan, balance, delta and inventory** views, with monitor tabs for the circuit and for individual objects.
+
+![Circuita — stochastic mineral-tracking engine and console](/images/projects/circuita_architecture.svg)
 
 ## What it demonstrates
 

--- a/_portfolio/Glissa.md
+++ b/_portfolio/Glissa.md
@@ -1,7 +1,7 @@
 ---
 title: "Glissa — Expressive Glissando Instrument"
 date: 2026-06-15
-excerpt: "A private mobile musical instrument whose signature is continuous glissando — slide smoothly between notes — backed by an FX rack, instrument morphing, sampled packs, and a Pro tier with cloud sync."
+excerpt: "A private mobile musical instrument whose signature is continuous glissando — slide smoothly between notes — backed by an FX rack, instrument morphing, sampled packs, and a Pro tier with cloud sync.<br/><img src='/images/projects/glissa_architecture.svg'>"
 collection: portfolio
 tags: [mobile, audio, music, synthesis, private]
 ---
@@ -9,6 +9,8 @@ tags: [mobile, audio, music, synthesis, private]
 > **Private product.** This is proprietary work; the app is private. This page describes the architecture and intent without exposing internal logic.
 
 Touchscreen instruments mostly imitate piano keys — discrete, quantized, expressively flat. **Glissa**'s signature is the hard, interesting thing: **continuous glissando**, letting a finger slide between pitches the way a voice or a slide guitar does, in real time, on a phone, with three modes — Keys, Glide, and Auto.
+
+![Glissa — expressive glissando instrument](/images/projects/glissa_architecture.svg)
 
 ## What it demonstrates
 

--- a/_portfolio/Mantia.md
+++ b/_portfolio/Mantia.md
@@ -1,7 +1,7 @@
 ---
 title: "Mantia — Agentic Industrial-Maintenance Suite"
 date: 2026-06-12
-excerpt: "A private suite of agentic assistants for industrial asset maintenance, shaped to enterprise EAM data via OData — a portal hub plus three specialist agents on one shared agent core."
+excerpt: "A private suite of agentic assistants for industrial asset maintenance, shaped to enterprise EAM data via OData — a portal hub plus three specialist agents on one shared agent core.<br/><img src='/images/projects/mantia_architecture.svg'>"
 collection: portfolio
 tags: [agentic-ai, maintenance, odata, eam, private]
 ---
@@ -13,6 +13,8 @@ tags: [agentic-ai, maintenance, odata, eam, private]
 ## The pattern
 
 The shared core is a generic **OData V2 connector** (with CSRF), an agent base, and a common web baseline. The connector runs against a faithful **mock** of the enterprise schema in development and a **real** backend in production — so the same agent code is developed, demoed, and validated without ever touching production, then promoted unchanged.
+
+![Mantia — agentic industrial-maintenance suite](/images/projects/mantia_architecture.svg)
 
 ## What it demonstrates
 

--- a/_portfolio/Ronquy.md
+++ b/_portfolio/Ronquy.md
@@ -1,7 +1,7 @@
 ---
 title: "Ronquy — On-Device Snore Detection"
 date: 2026-06-14
-excerpt: "A private mobile app that detects snoring on-device, overnight, with no audio ever leaving the phone — a YAMNet + TFLite model runs an 8-hour native audio-and-inference loop locally."
+excerpt: "A private mobile app that detects snoring on-device, overnight, with no audio ever leaving the phone — a YAMNet + TFLite model runs an 8-hour native audio-and-inference loop locally.<br/><img src='/images/projects/ronquy_architecture.svg'>"
 collection: portfolio
 tags: [mobile, audio-ml, on-device, yamnet, tflite, private]
 ---
@@ -13,6 +13,8 @@ tags: [mobile, audio-ml, on-device, yamnet, tflite, private]
 ## Why it matters
 
 Privacy is the product. A snore tracker that never uploads your sleep audio is fundamentally more trustworthy than one that does — and doing the inference on-device also means it works offline and costs nothing per night to run. An optional cloud mode (FastAPI + Postgres + own auth) lets a user register and sync results across devices, but the detection itself is fully local.
+
+![Ronquy — on-device snore detection](/images/projects/ronquy_architecture.svg)
 
 ## What it demonstrates
 

--- a/_portfolio/RotorVitals.md
+++ b/_portfolio/RotorVitals.md
@@ -1,0 +1,25 @@
+---
+title: "RotorVitals — Bearing Fault Diagnosis by Envelope Analysis"
+date: 2026-06-19
+excerpt: "Open, explainable diagnosis of rolling-element bearing faults from a vibration signal — entirely in the browser, showing its working. Field-standard envelope analysis, calibrated to the public CWRU benchmark.<br/><img src='/images/projects/rotorvitals_pipeline.svg'>"
+collection: portfolio
+tags: [predictive-maintenance, vibration, dsp, envelope-analysis, bearings, mining]
+---
+
+Open, explainable diagnosis of **rolling-element bearing faults** from a vibration signal — running entirely in the browser, showing its working. Bearings are the most common failure point of crushers, conveyors, pumps and fans; RotorVitals computes the bearing's kinematic defect frequencies, demodulates the resonance a defect excites, and reads the **envelope spectrum** for energy at exactly those lines. Live at [rotorvitals.fasl-work.com](https://rotorvitals.fasl-work.com), part of the [Faena](https://faena.fasl-work.com) mining-analytics hub.
+
+![RotorVitals — the envelope-analysis pipeline](/images/projects/rotorvitals_pipeline.svg)
+
+## The pipeline
+
+`signal → band-pass → Hilbert envelope → envelope spectrum → harmonic scoring → diagnosis`
+
+- **Kinematics** — BPFO / BPFI / BSF / FTF from bearing geometry and shaft speed (Randall & Antoni 2011).
+- **Envelope analysis** — band-pass around the structural resonance, the analytic signal via the Hilbert transform, magnitude, then its spectrum. A fault appears as a line at its kinematic frequency.
+- **Decision** — each fault is scored by summed peak energy at its first 5 harmonics, normalized by the noise floor; the top score wins above a floor gate, else "healthy". Every number traces to a computed line — no black box.
+
+## Honest about data
+
+No dataset is shipped or required: the engine is closed-form DSP and the demo signals are generated on-device from published physics (McFadden & Smith 1984), doubling as a self-validation set — the engine recovers the fault frequency that generated each. The SKF 6205/6203 geometries match the open **CWRU Bearing Data Center** rig, so the same pipeline reads real CWRU recordings unchanged. A single localized defect at steady speed is the easy case; real machines bring variable speed and multiple faults, but the frequency relationships are exact and transfer directly.
+
+[Live demo](https://rotorvitals.fasl-work.com) · [GitHub repository](https://github.com/fsantibanezleal/CAOS_RotorVitals)

--- a/_portfolio/SimLab.md
+++ b/_portfolio/SimLab.md
@@ -1,0 +1,28 @@
+---
+title: "CAOS SimLab — A Didactic Lab for Simulation (DES & ABM)"
+date: 2026-06-19
+excerpt: "Land straight in a running simulation, move the sliders, and watch the dynamics change. An open lab for Discrete-Event Simulation and Agent-Based Modeling — ten worked scenarios, each a pure function of (params, seed) so replay is exact.<br/><img src='/images/projects/simlab_architecture.svg'>"
+collection: portfolio
+tags: [simulation, des, abm, operations-research, pyodide, education]
+---
+
+An **open, didactic lab** for Discrete-Event Simulation (DES) and Agent-Based Modeling (ABM). Instead of a toy script or a GUI that hides the model, you arrive directly in a running simulation, move the sliders, and watch the dynamics change — across ten worked scenarios, with a from-zero curriculum that teaches the real tools (SimPy, Mesa, OR-Tools). Live at [simlab.fasl-work.com](https://simlab.fasl-work.com).
+
+![CAOS SimLab — one engine, two lanes, one render path](/images/projects/simlab_architecture.svg)
+
+## Two lanes, decided by measurement
+
+A run is a pure function of `(params, seed)` that produces a compact **trace**; the front end only animates it, so live and precomputed render through one code path — *replay is truth*. A measured 3-gate rule (pure-Python **and** under 3 s **and** trace under 1 MB) decides the lane:
+
+- **Live** — light scenarios run in your browser via [Pyodide](https://pyodide.org); edit parameters, re-run, watch it animate. No server, nothing to install.
+- **Precomputed** — heavy scenarios (native solvers like OR-Tools, large agent counts) are run offline into a seeded trace and replayed with a timeline scrubber under a clear "precomputed due to cost" banner.
+
+## Honest simulation
+
+The lab teaches what most demos skip: a single run is noisy, so results come from **replications + confidence intervals**; steady-state metrics need a **warm-up** cut; the same seed must reproduce the same result; and an animation is a hypothesis generator, not evidence. Each scenario validates against theory or a baseline where one exists — the M/M/c queue against the closed-form Erlang-C.
+
+## Coverage
+
+Ten scenarios across six visualization families (queue · agent-grid · chart · flow · gantt · route): bank/clinic queue, Schelling segregation, SIR epidemic, ED patient flow, the beer game, job-shop scheduling, construction haul routing, vehicle routing, ambulance dispatch, and a Monte-Carlo/CI study.
+
+[Live demo](https://simlab.fasl-work.com) · [GitHub repository](https://github.com/fsantibanezleal/CAOS_SIMLAB)

--- a/_portfolio/Veta.md
+++ b/_portfolio/Veta.md
@@ -1,7 +1,7 @@
 ---
 title: "Veta — Agentic Mineral-Tracking Decision Support"
 date: 2026-06-10
-excerpt: "A private decision-support system that turns a natural-language question — typed or spoken — about a mineral-processing operation into a traceable, evidence-backed answer."
+excerpt: "A private decision-support system that turns a natural-language question — typed or spoken — about a mineral-processing operation into a traceable, evidence-backed answer.<br/><img src='/images/projects/veta_architecture.svg'>"
 collection: portfolio
 tags: [mining, decision-support, agents, rag, private]
 ---
@@ -13,6 +13,8 @@ tags: [mining, decision-support, agents, rag, private]
 ## Why it exists
 
 In a plant, the knowledge needed to answer *"what should we do about this feed and these constraints?"* is spread across telemetry, historical runs, and expert intuition. Pulling it together is slow and hard to audit — and an answer with no traceable evidence is hard to trust on the floor. Veta compresses the loop from question to *defensible* recommendation and keeps the reasoning auditable rather than a black box.
+
+![Veta — agentic mineral-tracking decision support](/images/projects/veta_architecture.svg)
 
 ## What it demonstrates
 

--- a/_rollings/2026-06-19-01-simlab-rotorvitals-open.md
+++ b/_rollings/2026-06-19-01-simlab-rotorvitals-open.md
@@ -1,0 +1,30 @@
+---
+title: 'Two Tools That Show Their Working'
+date: 2026-06-19
+permalink: /rollings/2026/06/simlab-rotorvitals-open/
+tags:
+  - Simulation
+  - DSP
+  - PredictiveMaintenance
+  - OpenSource
+---
+
+Two Tools That Show Their Working
+======
+
+Two new things are live, both open, both running entirely in your browser, and both built around the same conviction: a tool you can't see inside is a tool you have to take on faith. I have spent enough time on the receiving end of black-box "it's fine, trust me" software to want the opposite.
+
+The first is **[CAOS SimLab](https://simlab.fasl-work.com)** — a didactic lab for Discrete-Event Simulation and Agent-Based Modeling. Most simulation tutorials stop at a toy script; most simulation tools hide the model behind a GUI. SimLab refuses both: you land in a running simulation, move the sliders, and watch the dynamics change, with the real engine (SimPy, Mesa, OR-Tools) underneath. The design decision I'm happiest with is that a run is a *pure function of (params, seed)* → a compact trace, and the front end only animates the trace. So "replay is truth", and a measured 3-gate rule decides honestly whether a scenario is light enough to run live in the browser (via Pyodide) or must be precomputed.
+
+![CAOS SimLab — one engine, two lanes, one render path](/images/projects/simlab_architecture.svg)
+
+The second is **[RotorVitals](https://rotorvitals.fasl-work.com)** — bearing fault diagnosis by envelope analysis, the field-standard method, done in the open. Bearings are the most common failure point of crushers, conveyors, pumps and fans, and the satisfying thing about this domain is that the physics gives you *exact* numbers to look for:
+
+<div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:'Courier New',monospace;color:#e0e0e0;font-size:13.5px;line-height:1.9;">
+<span style="color:#5a9ac0;"># kinematic defect frequencies from bearing geometry + shaft speed</span><br/>
+BPFO · BPFI · BSF · FTF<br/>
+<span style="color:#5a9ac0;"># a fault rings the resonance; demodulate it and read the spectrum</span><br/>
+signal → band-pass → Hilbert envelope → envelope spectrum → score the harmonics
+</div>
+
+A developing fault shows up as a line at its exact kinematic frequency, and the diagnosis is just: which fault's first five harmonics carry the most energy above the noise floor. Every number traces back to a computed line — no classifier you have to trust. It's calibrated to the public CWRU bearing benchmark, so the same pipeline that runs the synthetic demos reads real CWRU recordings unchanged. It's part of the [Faena](https://faena.fasl-work.com) mining-analytics hub. Both are MIT-spirited, open, and yours to poke at: [SimLab](https://github.com/fsantibanezleal/CAOS_SIMLAB) · [RotorVitals](https://github.com/fsantibanezleal/CAOS_RotorVitals).

--- a/images/projects/circuita_architecture.svg
+++ b/images/projects/circuita_architecture.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" width="800" height="400">
+  <title>Circuita — stochastic mineral-tracking engine and console</title>
+  <desc>A stochastic cellular-automaton engine simulates how material mixes and lags through a processing circuit; an operator console renders per-pile fan, balance, delta and inventory views, and a report builder emits a self-contained bilingual HTML file with inline-SVG charts.</desc>
+  <defs>
+    <linearGradient id="bgCI" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" style="stop-color:#0d1117"/><stop offset="100%" style="stop-color:#121a2b"/></linearGradient>
+    <marker id="arrCI" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><polygon points="0 0,9 3.5,0 7" fill="#29B6F6"/></marker>
+  </defs>
+  <rect width="800" height="400" fill="url(#bgCI)" rx="8"/>
+  <rect x="0" y="0" width="800" height="400" fill="none" stroke="#1f3a52" stroke-width="2" rx="8"/>
+  <text x="400" y="28" text-anchor="middle" font-family="Arial,sans-serif" font-size="15" font-weight="bold" fill="#29B6F6" letter-spacing="0.5">CIRCUITA — STOCHASTIC MINERAL-TRACKING ENGINE &amp; CONSOLE</text>
+  <text x="400" y="46" text-anchor="middle" font-family="Arial,sans-serif" font-size="8.5" fill="#6b8299">private product · architecture shown without internal data or logic</text>
+
+  <g font-family="Arial,sans-serif">
+    <!-- engine -->
+    <rect x="22" y="74" width="180" height="150" rx="6" fill="#0a1628" stroke="#e8a838" stroke-width="1.1"/>
+    <text x="112" y="94" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#e8a838">Stochastic CA engine</text>
+    <text x="112" y="110" text-anchor="middle" font-size="7.8" fill="#cfe0d8">material tracking through</text>
+    <text x="112" y="121" text-anchor="middle" font-size="7.8" fill="#cfe0d8">the processing circuit</text>
+    <!-- little CA grid -->
+    <g stroke="#5a4a1e" stroke-width="0.6">
+      <rect x="42" y="134" width="140" height="76" fill="#1c1607"/>
+      <line x1="42" y1="153" x2="182" y2="153"/><line x1="42" y1="172" x2="182" y2="172"/><line x1="42" y1="191" x2="182" y2="191"/>
+      <line x1="77" y1="134" x2="77" y2="210"/><line x1="112" y1="134" x2="112" y2="210"/><line x1="147" y1="134" x2="147" y2="210"/>
+    </g>
+    <rect x="77" y="153" width="35" height="19" fill="#e8a838" opacity="0.55"/>
+    <rect x="112" y="172" width="35" height="19" fill="#29B6F6" opacity="0.55"/>
+    <rect x="42" y="191" width="35" height="19" fill="#3ddc97" opacity="0.5"/>
+    <text x="112" y="222" text-anchor="middle" font-size="7" fill="#7d93a8">mixing · splits · lag the balance misses</text>
+
+    <!-- console views -->
+    <rect x="232" y="74" width="300" height="150" rx="6" fill="#0a1628" stroke="#1f3a52"/>
+    <text x="382" y="94" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#9fb3c8">Operator console — per-pile views</text>
+    <rect x="246" y="104" width="130" height="44" rx="4" fill="#11243b" stroke="#3a5a7c" stroke-width="0.7"/>
+    <text x="311" y="123" text-anchor="middle" font-size="8.4" fill="#cdd9e5">Fan</text>
+    <text x="311" y="137" text-anchor="middle" font-size="7.4" fill="#9fb3c8">composition spread</text>
+    <rect x="388" y="104" width="130" height="44" rx="4" fill="#11243b" stroke="#3a5a7c" stroke-width="0.7"/>
+    <text x="453" y="123" text-anchor="middle" font-size="8.4" fill="#cdd9e5">Balance</text>
+    <text x="453" y="137" text-anchor="middle" font-size="7.4" fill="#9fb3c8">in vs out</text>
+    <rect x="246" y="154" width="130" height="44" rx="4" fill="#11243b" stroke="#3a5a7c" stroke-width="0.7"/>
+    <text x="311" y="173" text-anchor="middle" font-size="8.4" fill="#cdd9e5">Delta</text>
+    <text x="311" y="187" text-anchor="middle" font-size="7.4" fill="#9fb3c8">expected vs actual</text>
+    <rect x="388" y="154" width="130" height="44" rx="4" fill="#11243b" stroke="#3a5a7c" stroke-width="0.7"/>
+    <text x="453" y="173" text-anchor="middle" font-size="8.4" fill="#cdd9e5">Inventory</text>
+    <text x="453" y="187" text-anchor="middle" font-size="7.4" fill="#9fb3c8">over time</text>
+    <text x="382" y="216" text-anchor="middle" font-size="7" fill="#7d93a8">monitor tabs: circuit · individual objects</text>
+
+    <!-- report -->
+    <rect x="562" y="74" width="216" height="150" rx="6" fill="#11243b" stroke="#3ddc97" stroke-width="1.3"/>
+    <text x="670" y="94" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#3ddc97">Self-contained report</text>
+    <text x="670" y="114" text-anchor="middle" font-size="8" fill="#bfe9d6">downsampled series per pile</text>
+    <text x="670" y="130" text-anchor="middle" font-size="8" fill="#bfe9d6">bilingual HTML + inline-SVG charts</text>
+    <text x="670" y="146" text-anchor="middle" font-size="8" fill="#bfe9d6">opens anywhere — no server</text>
+    <rect x="600" y="158" width="140" height="50" rx="4" fill="#0c2018" stroke="#2f6e54" stroke-width="0.8"/>
+    <polyline points="612,196 626,182 640,190 654,172 668,186 682,176 728,176" fill="none" stroke="#3ddc97" stroke-width="1.2"/>
+
+    <!-- arrows -->
+    <line x1="202" y1="149" x2="230" y2="149" stroke="#29B6F6" stroke-width="1.5" marker-end="url(#arrCI)"/>
+    <line x1="532" y1="149" x2="560" y2="149" stroke="#29B6F6" stroke-width="1.5" marker-end="url(#arrCI)"/>
+
+    <!-- footer -->
+    <rect x="22" y="244" width="756" height="58" rx="6" fill="#0c1622" stroke="#1f3a52"/>
+    <text x="400" y="266" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#e8a838">See where material actually goes — not where a static balance says it should</text>
+    <text x="400" y="285" text-anchor="middle" font-size="8.2" fill="#cdd9e5">simulate the real stochastic behavior, then make it legible and shareable</text>
+
+    <text x="400" y="330" text-anchor="middle" font-size="8.8" fill="#9fb3c8">Stack: TypeScript · Next.js · Python · FastAPI · cellular automata · SVG</text>
+    <text x="400" y="352" text-anchor="middle" font-size="8.4" fill="#7d93a8">private deployment · Azure Container Apps (Next build → Python serves)</text>
+  </g>
+</svg>

--- a/images/projects/glissa_architecture.svg
+++ b/images/projects/glissa_architecture.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" width="800" height="400">
+  <title>Glissa — expressive glissando instrument</title>
+  <desc>A touch surface drives a real-time audio engine whose signature is continuous glissando with Keys, Glide and Auto modes, layered with an FX rack, instrument morphing and sampled packs; a Pro tier adds recording, account, cloud sync and billing over a FastAPI and Postgres backend.</desc>
+  <defs>
+    <linearGradient id="bgGL" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" style="stop-color:#0d1117"/><stop offset="100%" style="stop-color:#121a2b"/></linearGradient>
+    <marker id="arrGL" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><polygon points="0 0,9 3.5,0 7" fill="#29B6F6"/></marker>
+  </defs>
+  <rect width="800" height="400" fill="url(#bgGL)" rx="8"/>
+  <rect x="0" y="0" width="800" height="400" fill="none" stroke="#1f3a52" stroke-width="2" rx="8"/>
+  <text x="400" y="28" text-anchor="middle" font-family="Arial,sans-serif" font-size="15" font-weight="bold" fill="#29B6F6" letter-spacing="0.5">GLISSA — EXPRESSIVE GLISSANDO INSTRUMENT</text>
+  <text x="400" y="46" text-anchor="middle" font-family="Arial,sans-serif" font-size="8.5" fill="#6b8299">private product · architecture shown without internal logic</text>
+
+  <g font-family="Arial,sans-serif">
+    <!-- touch -->
+    <rect x="22" y="78" width="130" height="120" rx="6" fill="#0a1628" stroke="#1f3a52"/>
+    <text x="87" y="98" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#9fb3c8">Touch surface</text>
+    <text x="87" y="116" text-anchor="middle" font-size="7.8" fill="#cdd9e5">finger slides between</text>
+    <text x="87" y="127" text-anchor="middle" font-size="7.8" fill="#cdd9e5">pitches in real time</text>
+    <text x="87" y="146" text-anchor="middle" font-size="7.6" fill="#7d93a8">two-finger octave pan</text>
+    <path d="M34,180 Q70,150 104,176 T140,166" fill="none" stroke="#3ddc97" stroke-width="1.4"/>
+
+    <!-- glissando engine -->
+    <rect x="184" y="78" width="190" height="120" rx="6" fill="#0a1628" stroke="#e8a838" stroke-width="1.2"/>
+    <text x="279" y="98" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#e8a838">Continuous glissando</text>
+    <text x="279" y="113" text-anchor="middle" font-size="7.8" fill="#cfe0d8">the signature feature</text>
+    <rect x="196" y="124" width="166" height="22" rx="3" fill="#1c1607" stroke="#5a4a1e" stroke-width="0.7"/>
+    <text x="279" y="139" text-anchor="middle" font-size="8" fill="#cfe0d8">Keys — discrete</text>
+    <rect x="196" y="150" width="166" height="22" rx="3" fill="#1c1607" stroke="#5a4a1e" stroke-width="0.7"/>
+    <text x="279" y="165" text-anchor="middle" font-size="8" fill="#cfe0d8">Glide — slide between notes</text>
+    <rect x="196" y="176" width="166" height="18" rx="3" fill="#1c1607" stroke="#5a4a1e" stroke-width="0.7"/>
+    <text x="279" y="189" text-anchor="middle" font-size="8" fill="#cfe0d8">Auto — guided</text>
+
+    <!-- audio chain -->
+    <rect x="406" y="78" width="170" height="120" rx="6" fill="#0a1628" stroke="#1f3a52"/>
+    <text x="491" y="98" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#9fb3c8">Audio chain</text>
+    <text x="491" y="118" text-anchor="middle" font-size="8" fill="#cdd9e5">FX rack</text>
+    <text x="491" y="136" text-anchor="middle" font-size="8" fill="#cdd9e5">instrument morph</text>
+    <text x="491" y="154" text-anchor="middle" font-size="8" fill="#cdd9e5">sampled packs</text>
+    <text x="491" y="178" text-anchor="middle" font-size="7.6" fill="#7d93a8">richer timbres</text>
+
+    <!-- pro suite -->
+    <rect x="608" y="78" width="170" height="120" rx="6" fill="#11243b" stroke="#3ddc97" stroke-width="1.3"/>
+    <text x="693" y="98" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#3ddc97">Pro suite</text>
+    <text x="693" y="118" text-anchor="middle" font-size="8" fill="#bfe9d6">local recording</text>
+    <text x="693" y="136" text-anchor="middle" font-size="8" fill="#bfe9d6">account + cloud sync</text>
+    <text x="693" y="154" text-anchor="middle" font-size="8" fill="#bfe9d6">own-JWT auth + billing</text>
+    <text x="693" y="178" text-anchor="middle" font-size="7.6" fill="#7d93a8">RevenueCat</text>
+
+    <!-- arrows -->
+    <line x1="152" y1="138" x2="182" y2="138" stroke="#29B6F6" stroke-width="1.5" marker-end="url(#arrGL)"/>
+    <line x1="374" y1="138" x2="404" y2="138" stroke="#29B6F6" stroke-width="1.5" marker-end="url(#arrGL)"/>
+    <line x1="576" y1="138" x2="606" y2="138" stroke="#3ddc97" stroke-width="1.5" marker-end="url(#arrGL)"/>
+
+    <!-- backend strip -->
+    <rect x="22" y="216" width="756" height="44" rx="6" fill="#0c1622" stroke="#1f3a52"/>
+    <text x="400" y="236" text-anchor="middle" font-size="9" font-weight="bold" fill="#9fb3c8">Cloud backend</text>
+    <text x="400" y="252" text-anchor="middle" font-size="8.2" fill="#cdd9e5">FastAPI + PostgreSQL + own auth · Pro sessions · cross-device sync</text>
+
+    <!-- footer -->
+    <rect x="22" y="272" width="756" height="106" rx="6" fill="#0a1628" stroke="#1f3a52"/>
+    <text x="400" y="296" text-anchor="middle" font-size="10" font-weight="bold" fill="#29B6F6">Expressive control is what separates a toy from an instrument</text>
+    <text x="400" y="318" text-anchor="middle" font-size="8.6" fill="#9fb3c8">a real-time audio engine with a distinctive expressive feature, not a keyboard clone</text>
+    <text x="400" y="340" text-anchor="middle" font-size="8.6" fill="#9fb3c8">a freemium → Pro ladder turns that expressiveness into a sustainable product</text>
+    <text x="400" y="362" text-anchor="middle" font-size="8.4" fill="#7d93a8">Stack: React Native · Expo · Web Audio · FastAPI · PostgreSQL · RevenueCat · standalone EAS build</text>
+  </g>
+</svg>

--- a/images/projects/mantia_architecture.svg
+++ b/images/projects/mantia_architecture.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" width="800" height="400">
+  <title>Mantia — agentic industrial-maintenance suite</title>
+  <desc>A portal hub catalogs three specialist maintenance agents (work-order generation, spares planning, notification triage), each a thin layer on one shared agent core: a generic OData connector with an agent base and a web baseline, running against a mock enterprise schema in development and a real backend in production.</desc>
+  <defs>
+    <linearGradient id="bgMA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" style="stop-color:#0d1117"/><stop offset="100%" style="stop-color:#121a2b"/></linearGradient>
+    <marker id="arrMA" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><polygon points="0 0,9 3.5,0 7" fill="#29B6F6"/></marker>
+  </defs>
+  <rect width="800" height="400" fill="url(#bgMA)" rx="8"/>
+  <rect x="0" y="0" width="800" height="400" fill="none" stroke="#1f3a52" stroke-width="2" rx="8"/>
+  <text x="400" y="28" text-anchor="middle" font-family="Arial,sans-serif" font-size="15" font-weight="bold" fill="#29B6F6" letter-spacing="0.5">MANTIA — AGENTIC INDUSTRIAL-MAINTENANCE SUITE</text>
+  <text x="400" y="46" text-anchor="middle" font-family="Arial,sans-serif" font-size="8.5" fill="#6b8299">private product · generic framing, no client names or internal logic</text>
+
+  <g font-family="Arial,sans-serif">
+    <!-- hub -->
+    <rect x="300" y="60" width="200" height="44" rx="6" fill="#11243b" stroke="#29B6F6" stroke-width="1.3"/>
+    <text x="400" y="79" text-anchor="middle" font-size="10" font-weight="bold" fill="#29B6F6">Portal hub</text>
+    <text x="400" y="95" text-anchor="middle" font-size="8" fill="#cdd9e5">agent catalog · lifecycle tiles · business case</text>
+
+    <!-- 3 agents -->
+    <rect x="60" y="132" width="200" height="56" rx="6" fill="#0a1628" stroke="#e8a838" stroke-width="1.1"/>
+    <text x="160" y="152" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#e8a838">Work-order generation</text>
+    <text x="160" y="170" text-anchor="middle" font-size="7.8" fill="#cfe0d8">drafts maintenance orders</text>
+    <text x="160" y="181" text-anchor="middle" font-size="7.8" fill="#cfe0d8">from a request + context</text>
+
+    <rect x="300" y="132" width="200" height="56" rx="6" fill="#0a1628" stroke="#e8a838" stroke-width="1.1"/>
+    <text x="400" y="152" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#e8a838">Spares planning</text>
+    <text x="400" y="170" text-anchor="middle" font-size="7.8" fill="#cfe0d8">reservations against</text>
+    <text x="400" y="181" text-anchor="middle" font-size="7.8" fill="#cfe0d8">material stock</text>
+
+    <rect x="540" y="132" width="200" height="56" rx="6" fill="#0a1628" stroke="#e8a838" stroke-width="1.1"/>
+    <text x="640" y="152" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#e8a838">Notification triage</text>
+    <text x="640" y="170" text-anchor="middle" font-size="7.8" fill="#cfe0d8">prioritizes incoming</text>
+    <text x="640" y="181" text-anchor="middle" font-size="7.8" fill="#cfe0d8">plant notifications</text>
+
+    <!-- arrows hub -> agents -->
+    <line x1="350" y1="104" x2="180" y2="130" stroke="#29B6F6" stroke-width="1.3" marker-end="url(#arrMA)"/>
+    <line x1="400" y1="104" x2="400" y2="130" stroke="#29B6F6" stroke-width="1.3" marker-end="url(#arrMA)"/>
+    <line x1="450" y1="104" x2="620" y2="130" stroke="#29B6F6" stroke-width="1.3" marker-end="url(#arrMA)"/>
+
+    <!-- shared core -->
+    <rect x="120" y="214" width="560" height="52" rx="6" fill="#0c1622" stroke="#3ddc97" stroke-width="1.2"/>
+    <text x="400" y="234" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#3ddc97">Shared agent core (acc_core)</text>
+    <text x="400" y="252" text-anchor="middle" font-size="8.2" fill="#bfe9d6">generic OData V2 (+CSRF) connector · agent base · common web baseline</text>
+    <line x1="160" y1="188" x2="300" y2="212" stroke="#3ddc97" stroke-width="1.2" marker-end="url(#arrMA)"/>
+    <line x1="400" y1="188" x2="400" y2="212" stroke="#3ddc97" stroke-width="1.2" marker-end="url(#arrMA)"/>
+    <line x1="640" y1="188" x2="500" y2="212" stroke="#3ddc97" stroke-width="1.2" marker-end="url(#arrMA)"/>
+
+    <!-- connector mode -->
+    <rect x="120" y="284" width="270" height="44" rx="6" fill="#0a1628" stroke="#1f3a52"/>
+    <text x="255" y="303" text-anchor="middle" font-size="9" font-weight="bold" fill="#9fb3c8">Mock enterprise schema</text>
+    <text x="255" y="319" text-anchor="middle" font-size="7.8" fill="#cdd9e5">development · build &amp; demo without touching prod</text>
+    <rect x="410" y="284" width="270" height="44" rx="6" fill="#0a1628" stroke="#1f3a52"/>
+    <text x="545" y="303" text-anchor="middle" font-size="9" font-weight="bold" fill="#9fb3c8">Real backend</text>
+    <text x="545" y="319" text-anchor="middle" font-size="7.8" fill="#cdd9e5">production · same agent code, promoted unchanged</text>
+    <text x="400" y="312" text-anchor="middle" font-size="11" font-weight="bold" fill="#e8a838">↔</text>
+
+    <!-- footer -->
+    <text x="400" y="350" text-anchor="middle" font-size="8.8" fill="#9fb3c8">Each new use case = a thin specialist agent on the shared core · Stack: FastAPI · Pydantic-AI · LiteLLM · HTMX · OData</text>
+    <text x="400" y="368" text-anchor="middle" font-size="8.4" fill="#7d93a8">live (private, access-controlled) · dual-target VPS + Azure Container Apps</text>
+  </g>
+</svg>

--- a/images/projects/ronquy_architecture.svg
+++ b/images/projects/ronquy_architecture.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" width="800" height="400">
+  <title>Ronquy — on-device snore detection</title>
+  <desc>A native overnight loop on the phone captures audio and runs a YAMNet model through TFLite locally for about eight hours; the raw audio never leaves the device and only derived events are stored, with an optional cloud account adding cross-device sync.</desc>
+  <defs>
+    <linearGradient id="bgRO" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" style="stop-color:#0d1117"/><stop offset="100%" style="stop-color:#121a2b"/></linearGradient>
+    <marker id="arrRO" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><polygon points="0 0,9 3.5,0 7" fill="#29B6F6"/></marker>
+  </defs>
+  <rect width="800" height="400" fill="url(#bgRO)" rx="8"/>
+  <rect x="0" y="0" width="800" height="400" fill="none" stroke="#1f3a52" stroke-width="2" rx="8"/>
+  <text x="400" y="28" text-anchor="middle" font-family="Arial,sans-serif" font-size="15" font-weight="bold" fill="#29B6F6" letter-spacing="0.5">RONQUY — ON-DEVICE SNORE DETECTION</text>
+  <text x="400" y="46" text-anchor="middle" font-family="Arial,sans-serif" font-size="8.5" fill="#6b8299">private product · privacy-first architecture, no internal logic shown</text>
+
+  <g font-family="Arial,sans-serif">
+    <!-- phone boundary -->
+    <rect x="40" y="64" width="470" height="210" rx="14" fill="#0a1628" stroke="#3ddc97" stroke-width="1.4"/>
+    <text x="275" y="84" text-anchor="middle" font-size="10" font-weight="bold" fill="#3ddc97">On the phone — audio never leaves the device</text>
+
+    <!-- mic -->
+    <rect x="60" y="100" width="120" height="70" rx="6" fill="#11243b" stroke="#3a5a7c" stroke-width="0.8"/>
+    <text x="120" y="122" text-anchor="middle" font-size="9" font-weight="bold" fill="#9fb3c8">Native loop</text>
+    <text x="120" y="139" text-anchor="middle" font-size="7.8" fill="#cdd9e5">capture audio</text>
+    <text x="120" y="151" text-anchor="middle" font-size="7.8" fill="#cdd9e5">~8 h overnight</text>
+    <text x="120" y="163" text-anchor="middle" font-size="7.4" fill="#7d93a8">battery-aware</text>
+
+    <!-- model -->
+    <rect x="200" y="100" width="130" height="70" rx="6" fill="#11243b" stroke="#e8a838" stroke-width="1.1"/>
+    <text x="265" y="122" text-anchor="middle" font-size="9" font-weight="bold" fill="#e8a838">On-device model</text>
+    <text x="265" y="139" text-anchor="middle" font-size="7.8" fill="#cfe0d8">YAMNet via TFLite</text>
+    <text x="265" y="151" text-anchor="middle" font-size="7.8" fill="#cfe0d8">(real, not a mock)</text>
+    <text x="265" y="163" text-anchor="middle" font-size="7.4" fill="#7d93a8">native, not a JS shim</text>
+
+    <!-- events -->
+    <rect x="350" y="100" width="140" height="70" rx="6" fill="#11243b" stroke="#3a5a7c" stroke-width="0.8"/>
+    <text x="420" y="122" text-anchor="middle" font-size="9" font-weight="bold" fill="#9fb3c8">Keep events only</text>
+    <text x="420" y="139" text-anchor="middle" font-size="7.8" fill="#cdd9e5">snore timestamps</text>
+    <text x="420" y="151" text-anchor="middle" font-size="7.8" fill="#cdd9e5">+ summaries</text>
+    <text x="420" y="163" text-anchor="middle" font-size="7.4" fill="#7d93a8">raw audio discarded</text>
+
+    <line x1="180" y1="135" x2="198" y2="135" stroke="#29B6F6" stroke-width="1.5" marker-end="url(#arrRO)"/>
+    <line x1="330" y1="135" x2="348" y2="135" stroke="#29B6F6" stroke-width="1.5" marker-end="url(#arrRO)"/>
+
+    <!-- works offline -->
+    <rect x="60" y="190" width="430" height="64" rx="6" fill="#0c2018" stroke="#2f6e54" stroke-width="0.9"/>
+    <text x="275" y="212" text-anchor="middle" font-size="9" font-weight="bold" fill="#3ddc97">Privacy is the product</text>
+    <text x="275" y="230" text-anchor="middle" font-size="8" fill="#bfe9d6">works fully offline · nothing to upload · zero per-night cost</text>
+    <text x="275" y="244" text-anchor="middle" font-size="7.6" fill="#9fb3c8">a snore tracker that never sees your sleep audio</text>
+
+    <!-- optional cloud -->
+    <rect x="560" y="110" width="210" height="120" rx="8" fill="#0a1628" stroke="#1f3a52" stroke-dasharray="5 4"/>
+    <text x="665" y="134" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#9fb3c8">Optional cloud</text>
+    <text x="665" y="154" text-anchor="middle" font-size="8" fill="#cdd9e5">register + sync</text>
+    <text x="665" y="170" text-anchor="middle" font-size="8" fill="#cdd9e5">across devices</text>
+    <text x="665" y="190" text-anchor="middle" font-size="7.8" fill="#7d93a8">FastAPI + Postgres</text>
+    <text x="665" y="204" text-anchor="middle" font-size="7.8" fill="#7d93a8">own auth</text>
+    <text x="665" y="220" text-anchor="middle" font-size="7.4" fill="#6b8299">events only — never raw audio</text>
+    <line x1="490" y1="150" x2="558" y2="150" stroke="#9fb3c8" stroke-width="1.2" stroke-dasharray="4 3" marker-end="url(#arrRO)"/>
+
+    <!-- footer -->
+    <rect x="40" y="290" width="730" height="90" rx="6" fill="#0c1622" stroke="#1f3a52"/>
+    <text x="405" y="314" text-anchor="middle" font-size="10" font-weight="bold" fill="#29B6F6">A hard mobile-ML pattern, end to end</text>
+    <text x="405" y="336" text-anchor="middle" font-size="8.6" fill="#9fb3c8">native, battery-aware, all-night audio + inference loop · a real model on-device · sensitive data never leaves the phone</text>
+    <text x="405" y="358" text-anchor="middle" font-size="8.6" fill="#9fb3c8">Stack: React Native · Expo · TensorFlow Lite (YAMNet) · FastAPI · PostgreSQL</text>
+    <text x="405" y="374" text-anchor="middle" font-size="8.4" fill="#7d93a8">private app · shipped as a standalone EAS build</text>
+  </g>
+</svg>

--- a/images/projects/rotorvitals_pipeline.svg
+++ b/images/projects/rotorvitals_pipeline.svg
@@ -1,0 +1,77 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" width="800" height="400">
+  <title>RotorVitals — bearing fault diagnosis by envelope analysis</title>
+  <desc>A vibration signal is band-passed around the structural resonance, demodulated with the Hilbert transform to an envelope, and its spectrum is read for energy at the bearing's kinematic defect frequencies (BPFO, BPFI, BSF); each fault is scored over its first five harmonics and the top score above a gate is the diagnosis. Calibrated to the CWRU benchmark, all in the browser.</desc>
+  <defs>
+    <linearGradient id="bgRV" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0d1117"/>
+      <stop offset="100%" style="stop-color:#131b2e"/>
+    </linearGradient>
+    <marker id="arrRV" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><polygon points="0 0,9 3.5,0 7" fill="#29B6F6"/></marker>
+  </defs>
+  <rect width="800" height="400" fill="url(#bgRV)" rx="8"/>
+  <rect x="0" y="0" width="800" height="400" fill="none" stroke="#1f3a52" stroke-width="2" rx="8"/>
+  <text x="400" y="28" text-anchor="middle" font-family="Arial,sans-serif" font-size="15" font-weight="bold" fill="#29B6F6" letter-spacing="0.5">ROTORVITALS — BEARING FAULT DIAGNOSIS BY ENVELOPE ANALYSIS</text>
+
+  <!-- pipeline stages -->
+  <g font-family="Arial,sans-serif">
+    <!-- 1 signal -->
+    <rect x="18" y="70" width="116" height="58" rx="6" fill="#0a1628" stroke="#1f3a52"/>
+    <text x="76" y="92" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#9fb3c8">Vibration signal</text>
+    <polyline points="30,116 42,104 50,120 60,100 70,118 80,103 92,119 104,106 118,116" fill="none" stroke="#3ddc97" stroke-width="1.2"/>
+    <!-- 2 band-pass -->
+    <rect x="160" y="70" width="116" height="58" rx="6" fill="#0a1628" stroke="#1f3a52"/>
+    <text x="218" y="92" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#9fb3c8">Band-pass</text>
+    <text x="218" y="108" text-anchor="middle" font-size="7.6" fill="#cdd9e5">around the</text>
+    <text x="218" y="119" text-anchor="middle" font-size="7.6" fill="#cdd9e5">resonance</text>
+    <!-- 3 hilbert envelope -->
+    <rect x="302" y="70" width="116" height="58" rx="6" fill="#0a1628" stroke="#1f3a52"/>
+    <text x="360" y="92" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#9fb3c8">Hilbert envelope</text>
+    <text x="360" y="108" text-anchor="middle" font-size="7.6" fill="#cdd9e5">analytic signal</text>
+    <text x="360" y="119" text-anchor="middle" font-size="7.6" fill="#cdd9e5">→ magnitude</text>
+    <!-- 4 envelope spectrum -->
+    <rect x="444" y="70" width="116" height="58" rx="6" fill="#11243b" stroke="#29B6F6" stroke-width="1.2"/>
+    <text x="502" y="92" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#29B6F6">Envelope spectrum</text>
+    <line x1="456" y1="120" x2="548" y2="120" stroke="#3a5a7c" stroke-width="0.8"/>
+    <line x1="470" y1="120" x2="470" y2="104" stroke="#29B6F6" stroke-width="1.6"/>
+    <line x1="492" y1="120" x2="492" y2="110" stroke="#29B6F6" stroke-width="1.6"/>
+    <line x1="514" y1="120" x2="514" y2="100" stroke="#29B6F6" stroke-width="1.6"/>
+    <line x1="536" y1="120" x2="536" y2="112" stroke="#29B6F6" stroke-width="1.6"/>
+    <!-- 5 harmonic scoring -->
+    <rect x="586" y="70" width="120" height="58" rx="6" fill="#0a1628" stroke="#1f3a52"/>
+    <text x="646" y="92" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#9fb3c8">Harmonic scoring</text>
+    <text x="646" y="108" text-anchor="middle" font-size="7.6" fill="#cdd9e5">Σ peak energy,</text>
+    <text x="646" y="119" text-anchor="middle" font-size="7.6" fill="#cdd9e5">first 5 harmonics</text>
+
+    <!-- arrows -->
+    <line x1="134" y1="99" x2="158" y2="99" stroke="#29B6F6" stroke-width="1.5" marker-end="url(#arrRV)"/>
+    <line x1="276" y1="99" x2="300" y2="99" stroke="#29B6F6" stroke-width="1.5" marker-end="url(#arrRV)"/>
+    <line x1="418" y1="99" x2="442" y2="99" stroke="#29B6F6" stroke-width="1.5" marker-end="url(#arrRV)"/>
+    <line x1="560" y1="99" x2="584" y2="99" stroke="#29B6F6" stroke-width="1.5" marker-end="url(#arrRV)"/>
+
+    <!-- kinematics feed -->
+    <rect x="302" y="156" width="258" height="58" rx="6" fill="#0d1117" stroke="#e8a838" stroke-width="1.1"/>
+    <text x="431" y="176" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#e8a838">Kinematic defect frequencies (from geometry + RPM)</text>
+    <text x="431" y="194" text-anchor="middle" font-size="8.4" fill="#cfe0d8">BPFO · BPFI · BSF · FTF — the exact lines to look for</text>
+    <text x="431" y="206" text-anchor="middle" font-size="7.4" fill="#9fb3c8">Randall &amp; Antoni 2011</text>
+    <line x1="431" y1="156" x2="460" y2="130" stroke="#e8a838" stroke-width="1.3" marker-end="url(#arrRV)"/>
+    <line x1="540" y1="160" x2="620" y2="130" stroke="#e8a838" stroke-width="1.3" marker-end="url(#arrRV)"/>
+
+    <!-- diagnosis -->
+    <rect x="586" y="156" width="120" height="58" rx="6" fill="#11243b" stroke="#3ddc97" stroke-width="1.3"/>
+    <text x="646" y="178" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#3ddc97">Diagnosis</text>
+    <text x="646" y="194" text-anchor="middle" font-size="7.6" fill="#bfe9d6">top score &gt; gate,</text>
+    <text x="646" y="205" text-anchor="middle" font-size="7.6" fill="#bfe9d6">else "healthy"</text>
+    <line x1="646" y1="128" x2="646" y2="154" stroke="#3ddc97" stroke-width="1.5" marker-end="url(#arrRV)"/>
+
+    <!-- bottom strip -->
+    <rect x="18" y="240" width="688" height="56" rx="6" fill="#0c1622" stroke="#1f3a52"/>
+    <text x="362" y="262" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#e8a838">No black box — every number traces to a computed envelope line</text>
+    <text x="362" y="281" text-anchor="middle" font-size="8.2" fill="#cdd9e5">closed-form DSP, 100% in the browser (FFT · Hilbert) · no dataset required · on-device synthetic signals double as a self-validation set</text>
+
+    <!-- footer -->
+    <rect x="18" y="312" width="688" height="66" rx="6" fill="#0a1628" stroke="#1f3a52"/>
+    <text x="362" y="336" text-anchor="middle" font-size="10" font-weight="bold" fill="#29B6F6">Calibrated to the public CWRU bearing benchmark (SKF 6205 / 6203)</text>
+    <text x="362" y="356" text-anchor="middle" font-size="8.4" fill="#9fb3c8">the same pipeline reads real CWRU recordings unchanged — frequency relationships are exact</text>
+    <text x="362" y="372" text-anchor="middle" font-size="8.4" fill="#7d93a8">live at rotorvitals.fasl-work.com · part of the Faena mining-analytics hub</text>
+  </g>
+</svg>

--- a/images/projects/simlab_architecture.svg
+++ b/images/projects/simlab_architecture.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" width="800" height="400">
+  <title>CAOS SimLab — deterministic-replay simulation: one engine, two lanes, one render path</title>
+  <desc>A scenario defined by parameters and a seed runs through one shared Python engine; a measured 3-gate rule sends it to the live in-browser Pyodide lane or the offline precomputed lane; both produce one trace that the front end animates through a single render path across six visualization families.</desc>
+  <defs>
+    <linearGradient id="bgSL" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0d1117"/>
+      <stop offset="100%" style="stop-color:#111a2b"/>
+    </linearGradient>
+    <marker id="arrSL" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><polygon points="0 0,9 3.5,0 7" fill="#29B6F6"/></marker>
+  </defs>
+  <rect width="800" height="400" fill="url(#bgSL)" rx="8"/>
+  <rect x="0" y="0" width="800" height="400" fill="none" stroke="#1f3a52" stroke-width="2" rx="8"/>
+  <text x="400" y="28" text-anchor="middle" font-family="Arial,sans-serif" font-size="15" font-weight="bold" fill="#29B6F6" letter-spacing="0.5">CAOS SIMLAB — DETERMINISTIC-REPLAY SIMULATION (DES &amp; ABM)</text>
+
+  <!-- scenario + engine -->
+  <rect x="16" y="60" width="150" height="120" rx="6" fill="#0a1628" stroke="#1f3a52"/>
+  <text x="91" y="80" text-anchor="middle" font-family="Arial,sans-serif" font-size="10" font-weight="bold" fill="#29B6F6">Scenario</text>
+  <rect x="28" y="90" width="126" height="22" rx="3" fill="#11243b" stroke="#3a5a7c" stroke-width="0.7"/>
+  <text x="91" y="105" text-anchor="middle" font-family="Arial,sans-serif" font-size="8.5" fill="#cdd9e5">params + seed</text>
+  <rect x="28" y="118" width="126" height="50" rx="3" fill="#11243b" stroke="#3a5a7c" stroke-width="0.7"/>
+  <text x="91" y="134" text-anchor="middle" font-family="Arial,sans-serif" font-size="8.5" font-weight="bold" fill="#9fb3c8">shared Python engine</text>
+  <text x="91" y="148" text-anchor="middle" font-family="Arial,sans-serif" font-size="7.5" fill="#9fb3c8">SimPy · Mesa</text>
+  <text x="91" y="160" text-anchor="middle" font-family="Arial,sans-serif" font-size="7.5" fill="#9fb3c8">OR-Tools</text>
+
+  <!-- 3-gate -->
+  <rect x="196" y="86" width="120" height="68" rx="6" fill="#0d1117" stroke="#e8a838" stroke-width="1.2"/>
+  <text x="256" y="104" text-anchor="middle" font-family="Arial,sans-serif" font-size="9.5" font-weight="bold" fill="#e8a838">3-gate rule</text>
+  <text x="256" y="120" text-anchor="middle" font-family="Arial,sans-serif" font-size="7.5" fill="#cfe0d8">pure-Python AND</text>
+  <text x="256" y="132" text-anchor="middle" font-family="Arial,sans-serif" font-size="7.5" fill="#cfe0d8">&lt; 3 s AND</text>
+  <text x="256" y="144" text-anchor="middle" font-family="Arial,sans-serif" font-size="7.5" fill="#cfe0d8">trace &lt; 1 MB</text>
+
+  <!-- live lane -->
+  <rect x="350" y="56" width="190" height="60" rx="6" fill="#0a1628" stroke="#3ddc97" stroke-width="1.1"/>
+  <text x="445" y="74" text-anchor="middle" font-family="Arial,sans-serif" font-size="9.5" font-weight="bold" fill="#3ddc97">LIVE lane</text>
+  <text x="445" y="90" text-anchor="middle" font-family="Arial,sans-serif" font-size="7.8" fill="#bfe9d6">Pyodide in browser</text>
+  <text x="445" y="102" text-anchor="middle" font-family="Arial,sans-serif" font-size="7.8" fill="#bfe9d6">tune params · re-run · animate</text>
+
+  <!-- precomputed lane -->
+  <rect x="350" y="124" width="190" height="60" rx="6" fill="#0a1628" stroke="#9fb3c8" stroke-width="1.1"/>
+  <text x="445" y="142" text-anchor="middle" font-family="Arial,sans-serif" font-size="9.5" font-weight="bold" fill="#9fb3c8">PRECOMPUTED lane</text>
+  <text x="445" y="158" text-anchor="middle" font-family="Arial,sans-serif" font-size="7.8" fill="#cdd9e5">offline → seeded trace</text>
+  <text x="445" y="170" text-anchor="middle" font-family="Arial,sans-serif" font-size="7.8" fill="#cdd9e5">replay with scrubber</text>
+
+  <!-- one trace / render path -->
+  <rect x="574" y="86" width="120" height="68" rx="6" fill="#11243b" stroke="#29B6F6" stroke-width="1.3"/>
+  <text x="634" y="106" text-anchor="middle" font-family="Arial,sans-serif" font-size="9.5" font-weight="bold" fill="#29B6F6">One trace</text>
+  <text x="634" y="122" text-anchor="middle" font-family="Arial,sans-serif" font-size="7.8" fill="#cdd9e5">one render path</text>
+  <text x="634" y="136" text-anchor="middle" font-family="Arial,sans-serif" font-size="7.8" fill="#cdd9e5">"replay = truth"</text>
+  <text x="634" y="150" text-anchor="middle" font-family="Arial,sans-serif" font-size="7.8" fill="#cdd9e5">6 viz families</text>
+
+  <!-- arrows -->
+  <line x1="166" y1="120" x2="194" y2="120" stroke="#29B6F6" stroke-width="1.5" marker-end="url(#arrSL)"/>
+  <line x1="316" y1="104" x2="348" y2="86" stroke="#3ddc97" stroke-width="1.5" marker-end="url(#arrSL)"/>
+  <line x1="316" y1="136" x2="348" y2="154" stroke="#9fb3c8" stroke-width="1.5" marker-end="url(#arrSL)"/>
+  <line x1="540" y1="86" x2="572" y2="108" stroke="#29B6F6" stroke-width="1.5" marker-end="url(#arrSL)"/>
+  <line x1="540" y1="154" x2="572" y2="132" stroke="#29B6F6" stroke-width="1.5" marker-end="url(#arrSL)"/>
+
+  <!-- honesty strip -->
+  <rect x="16" y="232" width="768" height="58" rx="6" fill="#0c1622" stroke="#1f3a52"/>
+  <text x="400" y="255" text-anchor="middle" font-family="Arial,sans-serif" font-size="10" font-weight="bold" fill="#e8a838">Honest simulation, not a pretty animation:</text>
+  <text x="400" y="275" text-anchor="middle" font-family="Arial,sans-serif" font-size="8.6" fill="#cdd9e5">replications + confidence intervals · warm-up cut · seed-reproducible · validated vs theory (M/M/c ↔ Erlang-C)</text>
+
+  <!-- scenarios footer -->
+  <rect x="16" y="306" width="768" height="74" rx="6" fill="#0a1628" stroke="#1f3a52"/>
+  <text x="400" y="330" text-anchor="middle" font-family="Arial,sans-serif" font-size="10" font-weight="bold" fill="#29B6F6">10 / 10 scenarios live · 6 visualization families</text>
+  <text x="400" y="350" text-anchor="middle" font-family="Arial,sans-serif" font-size="8.4" fill="#9fb3c8">queue · Schelling · SIR · ED flow · beer game · job-shop · haul · VRP · dispatch · Monte-Carlo/CI</text>
+  <text x="400" y="370" text-anchor="middle" font-family="Arial,sans-serif" font-size="8.4" fill="#7d93a8">live in the browser at simlab.fasl-work.com · MIT, public</text>
+</svg>

--- a/images/projects/veta_architecture.svg
+++ b/images/projects/veta_architecture.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" width="800" height="400">
+  <title>Veta — agentic mineral-tracking decision support</title>
+  <desc>A typed or spoken question enters a multi-stage agent pipeline that interprets intent, assembles plant state, and routes to a tiered solver; every recommendation is grounded with retrieval over the tracked sites' data and returned with its evidence, while an offline pipeline builds per-site content-addressed artifacts.</desc>
+  <defs>
+    <linearGradient id="bgVE" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" style="stop-color:#0d1117"/><stop offset="100%" style="stop-color:#121a2b"/></linearGradient>
+    <marker id="arrVE" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><polygon points="0 0,9 3.5,0 7" fill="#29B6F6"/></marker>
+  </defs>
+  <rect width="800" height="400" fill="url(#bgVE)" rx="8"/>
+  <rect x="0" y="0" width="800" height="400" fill="none" stroke="#1f3a52" stroke-width="2" rx="8"/>
+  <text x="400" y="28" text-anchor="middle" font-family="Arial,sans-serif" font-size="15" font-weight="bold" fill="#29B6F6" letter-spacing="0.5">VETA — AGENTIC MINERAL-TRACKING DECISION SUPPORT</text>
+  <text x="400" y="46" text-anchor="middle" font-family="Arial,sans-serif" font-size="8.5" fill="#6b8299">private product · architecture shown without internal data or logic</text>
+
+  <g font-family="Arial,sans-serif">
+    <!-- chat -->
+    <rect x="18" y="70" width="120" height="120" rx="6" fill="#0a1628" stroke="#1f3a52"/>
+    <text x="78" y="90" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#29B6F6">Ask</text>
+    <rect x="30" y="100" width="96" height="34" rx="3" fill="#11243b" stroke="#3a5a7c" stroke-width="0.7"/>
+    <text x="78" y="115" text-anchor="middle" font-size="8" fill="#cdd9e5">text question</text>
+    <text x="78" y="127" text-anchor="middle" font-size="8" fill="#cdd9e5">(typed)</text>
+    <rect x="30" y="140" width="96" height="34" rx="3" fill="#11243b" stroke="#3a5a7c" stroke-width="0.7"/>
+    <text x="78" y="155" text-anchor="middle" font-size="8" fill="#cdd9e5">voice question</text>
+    <text x="78" y="167" text-anchor="middle" font-size="8" fill="#cdd9e5">(speech-to-text)</text>
+
+    <!-- agent pipeline -->
+    <rect x="170" y="70" width="200" height="120" rx="6" fill="#0a1628" stroke="#e8a838" stroke-width="1.1"/>
+    <text x="270" y="90" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#e8a838">Multi-stage agent pipeline</text>
+    <rect x="182" y="100" width="176" height="22" rx="3" fill="#1c1607" stroke="#5a4a1e" stroke-width="0.7"/>
+    <text x="270" y="115" text-anchor="middle" font-size="8" fill="#cfe0d8">interpret intent</text>
+    <rect x="182" y="126" width="176" height="22" rx="3" fill="#1c1607" stroke="#5a4a1e" stroke-width="0.7"/>
+    <text x="270" y="141" text-anchor="middle" font-size="8" fill="#cfe0d8">assemble plant state</text>
+    <rect x="182" y="152" width="176" height="22" rx="3" fill="#1c1607" stroke="#5a4a1e" stroke-width="0.7"/>
+    <text x="270" y="167" text-anchor="middle" font-size="8" fill="#cfe0d8">route to the right solver tier</text>
+
+    <!-- solver tiers + RAG -->
+    <rect x="402" y="70" width="180" height="56" rx="6" fill="#0a1628" stroke="#1f3a52"/>
+    <text x="492" y="90" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#9fb3c8">Tiered solvers</text>
+    <text x="492" y="106" text-anchor="middle" font-size="7.8" fill="#cdd9e5">heuristics first →</text>
+    <text x="492" y="117" text-anchor="middle" font-size="7.8" fill="#cdd9e5">heavy optimization only if warranted</text>
+    <rect x="402" y="134" width="180" height="56" rx="6" fill="#0a1628" stroke="#3ddc97" stroke-width="1.1"/>
+    <text x="492" y="154" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#3ddc97">RAG evidence</text>
+    <text x="492" y="170" text-anchor="middle" font-size="7.8" fill="#bfe9d6">retrieval over tracked-site data</text>
+    <text x="492" y="181" text-anchor="middle" font-size="7.8" fill="#bfe9d6">grounds every recommendation</text>
+
+    <!-- answer -->
+    <rect x="614" y="84" width="168" height="92" rx="6" fill="#11243b" stroke="#29B6F6" stroke-width="1.3"/>
+    <text x="698" y="108" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#29B6F6">Traceable answer</text>
+    <text x="698" y="128" text-anchor="middle" font-size="8" fill="#cdd9e5">recommendation</text>
+    <text x="698" y="142" text-anchor="middle" font-size="8" fill="#cdd9e5">+ its evidence attached</text>
+    <text x="698" y="160" text-anchor="middle" font-size="8" fill="#cdd9e5">= auditable, not a black box</text>
+
+    <!-- arrows -->
+    <line x1="138" y1="130" x2="168" y2="130" stroke="#29B6F6" stroke-width="1.5" marker-end="url(#arrVE)"/>
+    <line x1="370" y1="118" x2="400" y2="100" stroke="#e8a838" stroke-width="1.4" marker-end="url(#arrVE)"/>
+    <line x1="370" y1="150" x2="400" y2="160" stroke="#e8a838" stroke-width="1.4" marker-end="url(#arrVE)"/>
+    <line x1="582" y1="118" x2="612" y2="128" stroke="#29B6F6" stroke-width="1.5" marker-end="url(#arrVE)"/>
+    <line x1="582" y1="158" x2="612" y2="142" stroke="#3ddc97" stroke-width="1.5" marker-end="url(#arrVE)"/>
+
+    <!-- offline strip -->
+    <rect x="18" y="210" width="764" height="50" rx="6" fill="#0c1622" stroke="#1f3a52"/>
+    <text x="400" y="231" text-anchor="middle" font-size="9.5" font-weight="bold" fill="#e8a838">Reproducible by construction</text>
+    <text x="400" y="249" text-anchor="middle" font-size="8.4" fill="#cdd9e5">offline pipeline → per-site, content-addressed (sha256-manifested) artifacts · multi-plant, feed × ops mode matrix</text>
+
+    <!-- footer -->
+    <rect x="18" y="276" width="764" height="104" rx="6" fill="#0a1628" stroke="#1f3a52"/>
+    <text x="400" y="300" text-anchor="middle" font-size="10" font-weight="bold" fill="#29B6F6">A conversational front door to defensible plant decisions</text>
+    <text x="400" y="322" text-anchor="middle" font-size="8.6" fill="#9fb3c8">one surface (text + voice) · staged agents · solver tiers that spend compute only when justified · RAG-grounded, traceable</text>
+    <text x="400" y="344" text-anchor="middle" font-size="8.6" fill="#9fb3c8">Stack: Python · FastAPI · LLM agents · RAG · speech-to-text · optimization</text>
+    <text x="400" y="366" text-anchor="middle" font-size="8.4" fill="#7d93a8">live (private) · dual-target VPS + Azure Container Apps</text>
+  </g>
+</svg>


### PR DESCRIPTION
Adds SimLab + RotorVitals portfolio cards (with diagrams); backfills an SVG on the 5 private cards (Veta/Mantia/Circuita/Ronquy/Glissa) so every portfolio entry carries a diagram; 1 rolling. Mirrors FASL_WEB_Portfolio #35/#36.