### PR TITLE
faena: reconcile the live-count claim with the registry

### DIFF
--- a/_portfolio/Faena.md
+++ b/_portfolio/Faena.md
@@ -12,7 +12,7 @@ The open **hub** for a growing family of independent, in-browser mining-analytic
 
 ## Honest by construction
 
-Every tile carries a lifecycle status, so the catalogue tells the truth about maturity: **3 live today** (ChargeCascade, RotorVitals, CutoffGrade Studio), **7 in active development**, and **~29 more mapped on the roadmap** — tiles advance *planned → building → live* as each one actually ships. "Live" means brought to the quality bar, not merely deployed. There is no "39 mining apps" claim — a small set that works today, and a visible plan for the rest.
+Every tile carries a lifecycle status, so the catalogue tells the truth about maturity: **4 live today** (DispatchLab, ChancaDEM, ChargeCascade, RotorVitals), **9 in active development**, and **29 more mapped on the roadmap** — tiles advance *planned → building → live* as each one actually ships. "Live" means brought to the quality bar, not merely deployed. There is no "39 mining apps" claim — a small set that works today, and a visible plan for the rest.
 
 ## How it is organized
 


### PR DESCRIPTION
Three surfaces quoted Faena lifecycle counts that disagreed with each other and with the authoritative registry (4 live / 9 building / 29 planned). The CV claimed 11 live, naming seven apps the registry marks building; the portfolio and personal card claimed 3 live and named CutoffGrade Studio while omitting DispatchLab and ChancaDEM. All three now state the registry's own numbers and the actual four, EN and ES. No product status was changed: that is Felipe's decision and the registry is untouched.