### PR TITLE
pitforge: stop publishing machine-dependent timings as product characteristics

### DIFF
--- a/_portfolio/PitForge.md
+++ b/_portfolio/PitForge.md
@@ -16,7 +16,7 @@ The exact result is the max-closure / min-cut equivalent of Lerchs-Grossmann, vi
 
 ## Validated against MineLib, not against itself
 
-The exact pit reproduces the published optima of three real MineLib instances: newman1 (1,060 blocks, 1.9 ms, relative error 9.96e-10), zuck_small (9,400 blocks, 111 ms, 1.86e-10), and kd (14,153 blocks / 219,778 precedences, 207 ms, 1.30e-10), as Node medians of three on the same TypeScript engine the browser runs. All three match. Three further instances (marvin, mclaughlin_limit, mclaughlin) are excluded with committed reasons rather than silently dropped. In real mode the scenario knobs are locked, because the instances publish their own net values and precedences and re-deriving them would break comparability with the published optimum.
+The exact pit reproduces the published optima of three real MineLib instances: newman1 (1,060 blocks, relative error 9.96e-10), zuck_small (9,400 blocks, 1.86e-10), and kd (14,153 blocks / 219,778 precedences, 1.30e-10). They solve in milliseconds to a fraction of a second under Node on the same TypeScript engine the browser runs, though that figure is machine-dependent: repeat runs on one laptop varied by a factor of several, so the artifact records its environment and no decimal is quoted here. All three match. Three further instances (marvin, mclaughlin_limit, mclaughlin) are excluded with committed reasons rather than silently dropped. In real mode the scenario knobs are locked, because the instances publish their own net values and precedences and re-deriving them would break comparability with the published optimum.
 
 ## The honest limit
 

--- a/_rollings/2026-08-06-pitforge-exact-is-a-checkable-claim.md
+++ b/_rollings/2026-08-06-pitforge-exact-is-a-checkable-claim.md
@@ -20,7 +20,7 @@ PitForge: "exact" is a checkable claim, so check it
 
 <div style="background:#0d1b2a;padding:16px 20px;border-radius:8px;margin:16px 0;font-family:Georgia,serif;color:#e0e0e0;font-size:15px;line-height:1.8;">
 <strong style="color:#e07830;">Three published MineLib optima, reproduced to 2e-9 relative error or better.</strong><br/>
-newman1 (1,060 blocks, 1.9 ms), zuck_small (9,400 blocks, 111 ms), kd (14,153 blocks and 219,778 precedences, 207 ms median), as Node medians of three on the same TypeScript engine the browser runs.<br/>
+newman1 (1,060 blocks), zuck_small (9,400 blocks), kd (14,153 blocks and 219,778 precedences), solving in milliseconds to a fraction of a second under Node on the same TypeScript engine the browser runs.<br/>
 <span style="color:#5a9ac0;font-size:13px;">Three further instances are excluded, with the reasons committed rather than omitted. The max-flow duality identity, pitValue = sum(positive) - maxflow, is asserted in the explicit-precedence MineLib lane and displayed as a live check on the interactive one, so a wrong answer cannot pass quietly.</span>
 </div>
 


### PR DESCRIPTION
The same MineLib instance measured 111, 234 and 527 ms across three runs on one laptop, so a tenth of a millisecond was false precision. The artifact now records its measurement environment (schema v3); these surfaces quote scale instead, with the machine dependence stated. Relative errors stay, because those are properties of the algorithm.