### PR TITLE
ci(talks): the talk-map scraper has been red since before June

### DIFF
--- a/.github/workflows/scrape_talks.yml
+++ b/.github/workflows/scrape_talks.yml
@@ -14,12 +14,12 @@ jobs:
       contents: write           # This workflow pushes to the repository
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.9'   # Specify the Python version you need
+        python-version: '3.11'  # python-frontmatter, pulled in by getorg, needs typing.TypeGuard (3.10+)
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/scrape_talks.yml
+++ b/.github/workflows/scrape_talks.yml
@@ -6,6 +6,7 @@ on:
       - 'talks/**'
       - '_talks/**'
       - 'talkmap.ipynb'
+  workflow_dispatch:        # so a broken scraper can be re-run without faking a talk edit
 
 jobs:
   build:

--- a/talkmap/org-locations.js
+++ b/talkmap/org-locations.js
@@ -1,10 +1,5 @@
 var addressPoints = [
   [
-    "Talk for Procemin Geomet 2020<br />Procemin Geomet 2020; Santiago, Chile",
-    -33.4376995,
-    -70.6510671
-  ],
-  [
     "Channelized facies recovery based on weighted compressed sensing<br />2016 IEEE Sensor Array and Multichannel Signal Processing Workshop (SAM); Rio de Janeiro, Brazil",
     -22.9110137,
     -43.2093727
@@ -13,6 +8,16 @@ var addressPoints = [
     "Geometallurgical estimation from hyperspectral images and topic modelling<br />18th International Conference on Mineral Processing and Geometallurgy (Procemin Geomet 2022); Santiago, Chile",
     -33.4376995,
     -70.6510671
+  ],
+  [
+    "Talk for Procemin Geomet 2020<br />Procemin Geomet 2020; Santiago, Chile",
+    -33.4376995,
+    -70.6510671
+  ],
+  [
+    "Mineral Tracking Models: five years of Codelco experience<br />Miner\u00eda Digital 2026; Hotel Sheraton, Santiago, Chile",
+    -33.4217661,
+    -70.6212185
   ],
   [
     "Talk of my doctoral dissertation defense<br />Doctoral Electric Engineering Program of the University of Chile; Santiago, Chile",

--- a/talkmap_out.ipynb
+++ b/talkmap_out.ipynb
@@ -29,10 +29,10 @@
    "metadata": {
     "collapsed": false,
     "execution": {
-     "iopub.execute_input": "2026-03-28T00:30:15.517501Z",
-     "iopub.status.busy": "2026-03-28T00:30:15.517190Z",
-     "iopub.status.idle": "2026-03-28T00:30:16.634413Z",
-     "shell.execute_reply": "2026-03-28T00:30:16.633604Z"
+     "iopub.execute_input": "2026-08-21T04:33:50.618939Z",
+     "iopub.status.busy": "2026-08-21T04:33:50.618759Z",
+     "iopub.status.idle": "2026-08-21T04:33:51.520624Z",
+     "shell.execute_reply": "2026-08-21T04:33:51.519858Z"
     }
    },
    "outputs": [
@@ -47,51 +47,39 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Downloading python_frontmatter-1.1.0-py3-none-any.whl.metadata (4.1 kB)\r\n",
-      "Requirement already satisfied: getorg in /opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages (0.3.1)\r\n"
+      "  Downloading python_frontmatter-1.3.0-py3-none-any.whl.metadata (4.4 kB)\r\n",
+      "Requirement already satisfied: getorg in /opt/hostedtoolcache/Python/3.11.16/x64/lib/python3.11/site-packages (0.3.1)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already satisfied: PyYAML in /opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages (from python-frontmatter) (6.0.3)\r\n",
-      "Requirement already satisfied: geopy in /opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages (from getorg) (2.4.1)\r\n",
-      "Requirement already satisfied: pygithub in /opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages (from getorg) (2.9.0)\r\n",
-      "Requirement already satisfied: retrying in /opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages (from getorg) (1.4.2)\r\n",
-      "Requirement already satisfied: geographiclib<3,>=1.52 in /opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages (from geopy->getorg) (2.1)\r\n",
-      "Requirement already satisfied: pynacl>=1.4.0 in /opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages (from pygithub->getorg) (1.6.2)\r\n",
-      "Requirement already satisfied: requests>=2.14.0 in /opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages (from pygithub->getorg) (2.32.5)\r\n",
-      "Requirement already satisfied: pyjwt>=2.4.0 in /opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages (from pyjwt[crypto]>=2.4.0->pygithub->getorg) (2.12.1)\r\n",
-      "Requirement already satisfied: typing-extensions>=4.5.0 in /opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages (from pygithub->getorg) (4.15.0)\r\n",
-      "Requirement already satisfied: urllib3>=1.26.0 in /opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages (from pygithub->getorg) (2.6.3)\r\n",
-      "Requirement already satisfied: cryptography>=3.4.0 in /opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages (from pyjwt[crypto]>=2.4.0->pygithub->getorg) (46.0.6)\r\n",
-      "Requirement already satisfied: cffi>=2.0.0 in /opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages (from cryptography>=3.4.0->pyjwt[crypto]>=2.4.0->pygithub->getorg) (2.0.0)\r\n",
-      "Requirement already satisfied: pycparser in /opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages (from cffi>=2.0.0->cryptography>=3.4.0->pyjwt[crypto]>=2.4.0->pygithub->getorg) (2.23)\r\n",
-      "Requirement already satisfied: charset_normalizer<4,>=2 in /opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages (from requests>=2.14.0->pygithub->getorg) (3.4.6)\r\n",
-      "Requirement already satisfied: idna<4,>=2.5 in /opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages (from requests>=2.14.0->pygithub->getorg) (3.11)\r\n",
-      "Requirement already satisfied: certifi>=2017.4.17 in /opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages (from requests>=2.14.0->pygithub->getorg) (2026.2.25)\r\n"
+      "Requirement already satisfied: pyyaml in /opt/hostedtoolcache/Python/3.11.16/x64/lib/python3.11/site-packages (from python-frontmatter) (6.0.3)\r\n",
+      "Requirement already satisfied: geopy in /opt/hostedtoolcache/Python/3.11.16/x64/lib/python3.11/site-packages (from getorg) (2.5.0)\r\n",
+      "Requirement already satisfied: pygithub in /opt/hostedtoolcache/Python/3.11.16/x64/lib/python3.11/site-packages (from getorg) (2.10.0)\r\n",
+      "Requirement already satisfied: retrying in /opt/hostedtoolcache/Python/3.11.16/x64/lib/python3.11/site-packages (from getorg) (1.4.2)\r\n",
+      "Requirement already satisfied: geographiclib<3,>=1.52 in /opt/hostedtoolcache/Python/3.11.16/x64/lib/python3.11/site-packages (from geopy->getorg) (2.1)\r\n",
+      "Requirement already satisfied: pynacl>=1.4.0 in /opt/hostedtoolcache/Python/3.11.16/x64/lib/python3.11/site-packages (from pygithub->getorg) (1.6.2)\r\n",
+      "Requirement already satisfied: requests>=2.14.0 in /opt/hostedtoolcache/Python/3.11.16/x64/lib/python3.11/site-packages (from pygithub->getorg) (2.34.2)\r\n",
+      "Requirement already satisfied: pyjwt>=2.4.0 in /opt/hostedtoolcache/Python/3.11.16/x64/lib/python3.11/site-packages (from pyjwt[crypto]>=2.4.0->pygithub->getorg) (2.13.0)\r\n",
+      "Requirement already satisfied: typing-extensions>=4.5.0 in /opt/hostedtoolcache/Python/3.11.16/x64/lib/python3.11/site-packages (from pygithub->getorg) (4.16.0)\r\n",
+      "Requirement already satisfied: urllib3>=1.26.0 in /opt/hostedtoolcache/Python/3.11.16/x64/lib/python3.11/site-packages (from pygithub->getorg) (2.7.0)\r\n",
+      "Requirement already satisfied: cryptography>=3.4.0 in /opt/hostedtoolcache/Python/3.11.16/x64/lib/python3.11/site-packages (from pyjwt[crypto]>=2.4.0->pygithub->getorg) (50.0.0)\r\n",
+      "Requirement already satisfied: cffi>=2.0.0 in /opt/hostedtoolcache/Python/3.11.16/x64/lib/python3.11/site-packages (from cryptography>=3.4.0->pyjwt[crypto]>=2.4.0->pygithub->getorg) (2.1.1)\r\n",
+      "Requirement already satisfied: pycparser in /opt/hostedtoolcache/Python/3.11.16/x64/lib/python3.11/site-packages (from cffi>=2.0.0->cryptography>=3.4.0->pyjwt[crypto]>=2.4.0->pygithub->getorg) (3.0)\r\n",
+      "Requirement already satisfied: charset_normalizer<4,>=2 in /opt/hostedtoolcache/Python/3.11.16/x64/lib/python3.11/site-packages (from requests>=2.14.0->pygithub->getorg) (3.5.1)\r\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /opt/hostedtoolcache/Python/3.11.16/x64/lib/python3.11/site-packages (from requests>=2.14.0->pygithub->getorg) (3.19)\r\n",
+      "Requirement already satisfied: certifi>=2023.5.7 in /opt/hostedtoolcache/Python/3.11.16/x64/lib/python3.11/site-packages (from requests>=2.14.0->pygithub->getorg) (2026.7.22)\r\n",
+      "Downloading python_frontmatter-1.3.0-py3-none-any.whl (10 kB)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Downloading python_frontmatter-1.1.0-py3-none-any.whl (9.8 kB)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Installing collected packages: python-frontmatter\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Successfully installed python-frontmatter-1.1.0\r\n"
+      "Installing collected packages: python-frontmatter\r\n",
+      "Successfully installed python-frontmatter-1.3.0\r\n"
      ]
     },
     {
@@ -122,10 +110,10 @@
    "metadata": {
     "collapsed": false,
     "execution": {
-     "iopub.execute_input": "2026-03-28T00:30:16.637387Z",
-     "iopub.status.busy": "2026-03-28T00:30:16.637099Z",
-     "iopub.status.idle": "2026-03-28T00:30:16.640549Z",
-     "shell.execute_reply": "2026-03-28T00:30:16.639852Z"
+     "iopub.execute_input": "2026-08-21T04:33:51.522624Z",
+     "iopub.status.busy": "2026-08-21T04:33:51.522369Z",
+     "iopub.status.idle": "2026-08-21T04:33:51.525447Z",
+     "shell.execute_reply": "2026-08-21T04:33:51.524882Z"
     }
    },
    "outputs": [],
@@ -140,10 +128,10 @@
    "metadata": {
     "collapsed": true,
     "execution": {
-     "iopub.execute_input": "2026-03-28T00:30:16.642863Z",
-     "iopub.status.busy": "2026-03-28T00:30:16.642653Z",
-     "iopub.status.idle": "2026-03-28T00:30:16.670294Z",
-     "shell.execute_reply": "2026-03-28T00:30:16.669613Z"
+     "iopub.execute_input": "2026-08-21T04:33:51.527099Z",
+     "iopub.status.busy": "2026-08-21T04:33:51.526958Z",
+     "iopub.status.idle": "2026-08-21T04:33:51.549280Z",
+     "shell.execute_reply": "2026-08-21T04:33:51.548561Z"
     }
    },
    "outputs": [],
@@ -172,10 +160,10 @@
    "metadata": {
     "collapsed": false,
     "execution": {
-     "iopub.execute_input": "2026-03-28T00:30:16.672377Z",
-     "iopub.status.busy": "2026-03-28T00:30:16.672116Z",
-     "iopub.status.idle": "2026-03-28T00:30:18.606459Z",
-     "shell.execute_reply": "2026-03-28T00:30:18.605868Z"
+     "iopub.execute_input": "2026-08-21T04:33:51.550846Z",
+     "iopub.status.busy": "2026-08-21T04:33:51.550677Z",
+     "iopub.status.idle": "2026-08-21T04:33:53.194037Z",
+     "shell.execute_reply": "2026-08-21T04:33:53.193355Z"
     }
    },
    "outputs": [
@@ -183,6 +171,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Channelized facies recovery based on weighted compressed sensing<br />2016 IEEE Sensor Array and Multichannel Signal Processing Workshop (SAM); Rio de Janeiro, Brazil Rio de Janeiro, Região Sudeste, Brasil\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Geometallurgical estimation from hyperspectral images and topic modelling<br />18th International Conference on Mineral Processing and Geometallurgy (Procemin Geomet 2022); Santiago, Chile Santiago, Provincia de Santiago, Región Metropolitana de Santiago, 8320000, Chile\n",
       "Talk for Procemin Geomet 2020<br />Procemin Geomet 2020; Santiago, Chile Santiago, Provincia de Santiago, Región Metropolitana de Santiago, 8320000, Chile\n"
      ]
     },
@@ -190,15 +186,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Channelized facies recovery based on weighted compressed sensing<br />2016 IEEE Sensor Array and Multichannel Signal Processing Workshop (SAM); Rio de Janeiro, Brazil Rio de Janeiro, Região Geográfica Imediata do Rio de Janeiro, Região Metropolitana do Rio de Janeiro, Região Geográfica Intermediária do Rio de Janeiro, Rio de Janeiro, Região Sudeste, Brasil\n",
-      "Geometallurgical estimation from hyperspectral images and topic modelling<br />18th International Conference on Mineral Processing and Geometallurgy (Procemin Geomet 2022); Santiago, Chile Santiago, Provincia de Santiago, Región Metropolitana de Santiago, 8320000, Chile\n"
+      "Analysis of seismic tomography and geological data using ML methods<br />AGU Fall Meeting 2021; New Orleans, USA (hybrid) None\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Analysis of seismic tomography and geological data using ML methods<br />AGU Fall Meeting 2021; New Orleans, USA (hybrid) None\n",
+      "Mineral Tracking Models: five years of Codelco experience<br />Minería Digital 2026; Hotel Sheraton, Santiago, Chile Sheraton San Cristobal, 1742, Los Conquistadores, Pedro de Valdivia Norte, Providencia, Provincia de Santiago, Región Metropolitana de Santiago, 7500000, Chile\n",
       "Talk of my doctoral dissertation defense<br />Doctoral Electric Engineering Program of the University of Chile; Santiago, Chile Santiago, Provincia de Santiago, Región Metropolitana de Santiago, 8320000, Chile\n"
      ]
     }
@@ -238,10 +233,10 @@
    "metadata": {
     "collapsed": false,
     "execution": {
-     "iopub.execute_input": "2026-03-28T00:30:18.608389Z",
-     "iopub.status.busy": "2026-03-28T00:30:18.608178Z",
-     "iopub.status.idle": "2026-03-28T00:30:18.615703Z",
-     "shell.execute_reply": "2026-03-28T00:30:18.615193Z"
+     "iopub.execute_input": "2026-08-21T04:33:53.195991Z",
+     "iopub.status.busy": "2026-08-21T04:33:53.195839Z",
+     "iopub.status.idle": "2026-08-21T04:33:53.202358Z",
+     "shell.execute_reply": "2026-08-21T04:33:53.201633Z"
     }
    },
    "outputs": [
@@ -289,7 +284,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.25"
+   "version": "3.11.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
`python-frontmatter`, pulled in by `getorg`, imports `typing.TypeGuard`, which does not exist on the pinned Python 3.9. Every run since PR #29 failed at import, so the talk map stopped regenerating and nothing said so. Pinned to 3.11, and `checkout`/`setup-python` moved off the deprecated v2.

The workflow also only triggered on a talk edit, so verifying a fix to the workflow itself meant faking a content change; it now accepts `workflow_dispatch`.

Verified by dispatching it: run 32447346667 is green, the first success since PR #29.